### PR TITLE
[Community Class] Jedi Kindred Duo

### DIFF
--- a/z_MBLegends/ext_data/mb2/character/h10_JHeal.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JHeal.mbch
@@ -16,44 +16,38 @@ ClassInfo
 	modelscale       0.97
 	speed 1
 	saberThrowDamage 40
-	model		"barriss_offee"
-	skin			"default"
-	uishader		"models/players/barriss_offee/mb2_icon_default"
-	
-	model_2		"adigallia"
-	skin_2		"robed"
-	uishader_2	"models/players/adigallia/mb2_icon_robed"
+
+	model		"adigallia"
+	skin		"robed"
+	uishader	"models/players/adigallia/mb2_icon_robed"
 	
 	model_1 		"adigallia"
 	skin_1		"default"
 	uishader_1 	"models/players/adigallia/mb2_icon_default"
 	
-	model_3		"jedi_kotor"
-	skin_3		"zhar"
-	uishader_3	"models/players/jedi_kotor/mb2_icon_zhar"
+	model_2		"jedi_kotor"
+	skin_2		"zhar"
+	uishader_2	"models/players/jedi_kotor/mb2_icon_zhar"
+	
+	model_3		"rey"
+	skin_3		"default"
+	uishader_3	"models/players/rey/mb2_icon_default"
 	
 	model_4		"rey"
-	skin_4		"default"
-	uishader_4	"models/players/rey/mb2_icon_default"
+	skin_4		"jedi"
+	uishader_4	"models/players/rey/mb2_icon_jedi"
+		
+	saber1			saber_adi
+	sabercolor		3
 	
-	model_5		"rey"
-	skin_5		"jedi"
-	uishader_5	"models/players/rey/mb2_icon_jedi"
-	
-	saber1			saber_barriss_legends
-	sabercolor		4
-	
-	saber1_1			saber_adi
-	sabercolor_1		3
-	
-	saber1_2			kotorsab
-	sabercolor_2		1
+	saber1_1			kotorsab
+	sabercolor_1		1
 
-	saber1_3			saber_rey
-	sabercolor_3		4
+	saber1_2			saber_rey
+	sabercolor_2		4
 	
-	saber1_4			saber_rey5
-	sabercolor_4		1
+	saber1_3			saber_rey5
+	sabercolor_3		1
 
 	holdables			HI_MEDPAC_BIG
 

--- a/z_MBLegends/ext_data/mb2/character/h10_JKindredAbsorb.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JKindredAbsorb.mbch
@@ -1,0 +1,84 @@
+// Air
+ClassInfo
+{
+	name			"h10_JKindred(Absorb)"
+	weapons			WP_MELEE|WP_SABER
+	saberstyle		SS_MEDIUM|SS_FAST
+	forcepowers		FP_SABER_OFFENSE,1|FP_LEVITATION,2|FP_PUSH,1|FP_PULL,2|FP_ABSORB,1|FP_SEE,1|FP_SABERTHROW,2
+	attributes		MB_ATT_FORCEBLOCK,2|MB_ATT_DEFLECT,2|MB_ATT_FORCEFOCUS,1|MB_ATT_GUN_DEFENSE,2|MB_ATT_FP_SABER_DEFENSE,1|MB_ATT_LIGHTS_BEACON
+	
+	basespeed		230
+	
+	BPmultiplier	1.1
+	APmultiplier	1
+	ASmultiplier 	1.0
+	CSmultiplier	1.05
+	saberThrowDamage 40
+	forcepool	120
+	skilltimermod 3
+	maxhealth	120
+	modelscale	1
+	MBClass		MB_CLASS_JEDI
+	classflags CFL_NOPICKUPS
+
+	
+	special2	EAS_MELEE
+	
+	special3    EAS_FP_ABSORB
+	
+	special4	EAS_FP_SABERTHROW
+	
+	classNumberLimit	1
+	
+	uioverlay "gfx/icons/support"
+	
+	forceregen       1
+	
+	saber1			saber_barriss_legends
+	sabercolor		4
+	
+	saber1_1		tiplee_legends
+	sabercolor_1	4
+	
+	saber1_2		agen_kolar_legends
+	sabercolor_2	4
+	
+	model		"barriss_offee"
+	skin		"default"
+	uishader	"models/players/barriss_offee/mb2_icon_default"
+	
+	model_1 	"tiplee"
+	skin_1		"default"
+	uishader_1	"models/players/tiplee/mb2_icon_default"
+	
+	model_2 	"eeth_koth"
+	skin_2		"agenkolar"
+	uishader_2	"models/players/eeth_koth/mb2_icon_agenkolar"
+}
+
+description	"Defensive Jedi Kindred [Jedi]
+			A single jedi from a typical pair. 
+Defensive support that can absorb others force powers whilst being vulnerable to physical harm.
+
+^2Weaponry:
+- Melee
+- Lightsaber (Yellow/Blue)
+-- Saber Defense (1)
+-- Blaster Defense (2)
+-- Saber Deflect (2)
+-- EX Saber Throw (2) ^3[CS1]
+--- 33% more DMG
+-- Slap ^3[CS2]
+
+^5Force Powers:
+- Jump (2)
+- Push (1)
+- Pull (2)
+- Sense (1) 
+- Absorb (1) ^3[CS3]
+
+^8Attributes:
+- Force Block (2)
+- Force Focus (1)
+^7- ^3*^7Light's Beacon (Shares Force Powers with a ^7targeted/nearby ally)
+- 200% slower skill CD"

--- a/z_MBLegends/ext_data/mb2/character/h10_JKindredAbsorb.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JKindredAbsorb.mbch
@@ -4,7 +4,7 @@ ClassInfo
 	name			"h10_JKindred(Absorb)"
 	weapons			WP_MELEE|WP_SABER
 	saberstyle		SS_MEDIUM|SS_FAST
-	forcepowers		FP_SABER_OFFENSE,1|FP_LEVITATION,2|FP_PUSH,1|FP_PULL,2|FP_ABSORB,1|FP_SEE,1|FP_SABERTHROW,2
+	forcepowers		FP_SABER_OFFENSE,1|FP_LEVITATION,2|FP_PUSH,1|FP_PULL,2|FP_ABSORB,1|FP_SEE,1|FP_SABERTHROW,2|FP_DEADLYSIGHT
 	attributes		MB_ATT_FORCEBLOCK,2|MB_ATT_DEFLECT,2|MB_ATT_FORCEFOCUS,1|MB_ATT_GUN_DEFENSE,2|MB_ATT_FP_SABER_DEFENSE,1|MB_ATT_LIGHTS_BEACON
 	
 	basespeed		230
@@ -21,12 +21,13 @@ ClassInfo
 	MBClass		MB_CLASS_JEDI
 	classflags CFL_NOPICKUPS
 
+	special1	EAS_FP_SABERTHROW
 	
 	special2	EAS_MELEE
 	
 	special3    EAS_FP_ABSORB
 	
-	special4	EAS_FP_SABERTHROW
+	special4	EAS_FP_DEADLYSIGHT
 	
 	classNumberLimit	1
 	
@@ -76,6 +77,7 @@ Defensive support that can absorb others force powers whilst being vulnerable to
 - Pull (2)
 - Sense (1) 
 - Absorb (1) ^3[CS3]
+- Deadly Sight (1) ^3[CS4]
 
 ^8Attributes:
 - Force Block (2)

--- a/z_MBLegends/ext_data/mb2/character/h10_JKindredAbsorb.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JKindredAbsorb.mbch
@@ -84,4 +84,3 @@ Defensive support that can absorb others force powers whilst being vulnerable to
 - Force Focus (1)
 ^7- ^3*^7Light's Beacon (Shares Force Powers with a ^7targeted/nearby ally)
 - 200% slower skill CD"
-

--- a/z_MBLegends/ext_data/mb2/character/h10_JKindredAbsorb.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JKindredAbsorb.mbch
@@ -4,7 +4,7 @@ ClassInfo
 	name			"h10_JKindred(Absorb)"
 	weapons			WP_MELEE|WP_SABER
 	saberstyle		SS_MEDIUM|SS_FAST
-	forcepowers		FP_SABER_OFFENSE,1|FP_LEVITATION,2|FP_PUSH,1|FP_PULL,2|FP_ABSORB,1|FP_SEE,1|FP_SABERTHROW,2|FP_DEADLYSIGHT
+	forcepowers		FP_SABER_OFFENSE,1|FP_LEVITATION,3|FP_PUSH,1|FP_PULL,3|FP_ABSORB,1|FP_SEE,1|FP_SABERTHROW,2|FP_DEADLYSIGHT
 	attributes		MB_ATT_FORCEBLOCK,2|MB_ATT_DEFLECT,2|MB_ATT_FORCEFOCUS,1|MB_ATT_GUN_DEFENSE,2|MB_ATT_FP_SABER_DEFENSE,1|MB_ATT_LIGHTS_BEACON
 	
 	basespeed		230
@@ -72,9 +72,9 @@ Defensive support that can absorb others force powers whilst being vulnerable to
 -- Slap ^3[CS2]
 
 ^5Force Powers:
-- Jump (2)
+- Jump (3)
+- Pull (3)
 - Push (1)
-- Pull (2)
 - Sense (1) 
 - Absorb (1) ^3[CS3]
 - Deadly Sight (1) ^3[CS4]
@@ -84,3 +84,4 @@ Defensive support that can absorb others force powers whilst being vulnerable to
 - Force Focus (1)
 ^7- ^3*^7Light's Beacon (Shares Force Powers with a ^7targeted/nearby ally)
 - 200% slower skill CD"
+

--- a/z_MBLegends/ext_data/mb2/character/h10_JKindredProtect.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JKindredProtect.mbch
@@ -1,0 +1,83 @@
+// Air
+ClassInfo
+{
+	name			"h10_JKindred(Protect)"
+	weapons			WP_MELEE|WP_SABER
+	saberstyle		SS_MEDIUM|SS_STRONG
+	forcepowers		FP_SABER_OFFENSE,2|FP_LEVITATION,2|FP_PUSH,2|FP_PULL,1|FP_PROTECT,1|FP_SEE,1|FP_SABERTHROW,2
+	attributes		MB_ATT_FORCEBLOCK,1|MB_ATT_DEFLECT,2|MB_ATT_FORCEFOCUS,2|MB_ATT_GUN_DEFENSE,1|MB_ATT_FP_SABER_DEFENSE,2|MB_ATT_LIGHTS_BEACON
+	
+	basespeed		230
+	
+	BPmultiplier	1.0
+	APmultiplier	1.1
+	ASmultiplier 	1.05
+	CSmultiplier	1
+	saberThrowDamage 40
+	forcepool	120
+	skilltimermod 3
+	maxhealth	120
+	modelscale	1
+	MBClass		MB_CLASS_JEDI
+	classflags CFL_NOPICKUPS
+
+	
+	special2	EAS_MELEE
+	special3 EAS_FP_PROTECT
+	
+	
+	classNumberLimit	1
+	
+	uioverlay "gfx/icons/support"
+	
+	forceregen       1
+	
+	saber1			saber_luminara
+	sabercolor		3
+	
+	saber1_1		tiplar_legends
+	sabercolor_1	3
+	
+	saber1_2		eeth_koth_legends
+	sabercolor_2	3
+	
+	model		"luminara"
+	skin		"default"
+	uishader	"models/players/luminara/mb2_icon_default"
+	
+	model_1		"tiplee"	
+	skin_1		"tiplar"
+	uishader_1	"models/players/tiplee/mb2_icon_tiplar"
+	
+	model_2		"eeth_koth"
+	skin_2		"default"
+	uishader_2	"models/players/eeth_koth/mb2_icon_default"  	
+	
+}
+
+description	"Aggressive Jedi Kindred [Jedi]
+		A single jedi from a typical pair. 
+Aggressive support that can protect others from physical harm whilst being vulnerable to the force.
+
+^2Weaponry:
+- Melee
+- Lightsaber (Yellow/Red)
+-- Saber Defense (2)
+-- Blaster Defense (1)
+-- Saber Deflect (2)
+-- EX Saber Throw (2) ^3[CS1]
+--- 33% more DMG
+-- Slap ^3[CS2]
+
+^5Force Powers:
+- Jump (2)
+- Push (2)
+- Pull (1)
+- Sense (1) 
+- Protect (1) ^3[CS3]
+
+^8Attributes:
+- Force Block (1)
+- Force Focus (2)
+^7- ^3*^7Light's Beacon (Shares Force Powers with a ^7targeted/nearby ally)
+- 200% slower skill CD"

--- a/z_MBLegends/ext_data/mb2/character/h10_JKindredProtect.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JKindredProtect.mbch
@@ -82,5 +82,4 @@ Aggressive support that can protect others from physical harm whilst being vulne
 - Force Block (1)
 - Force Focus (2)
 ^7- ^3*^7Light's Beacon (Shares Force Powers with a ^7targeted/nearby ally)
-
 - 200% slower skill CD"

--- a/z_MBLegends/ext_data/mb2/character/h10_JKindredProtect.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JKindredProtect.mbch
@@ -4,7 +4,7 @@ ClassInfo
 	name			"h10_JKindred(Protect)"
 	weapons			WP_MELEE|WP_SABER
 	saberstyle		SS_MEDIUM|SS_STRONG
-	forcepowers		FP_SABER_OFFENSE,2|FP_LEVITATION,2|FP_PUSH,2|FP_PULL,1|FP_PROTECT,1|FP_SEE,1|FP_SABERTHROW,2
+	forcepowers		FP_SABER_OFFENSE,2|FP_LEVITATION,3|FP_PUSH,3|FP_PULL,1|FP_PROTECT,1|FP_SEE,1|FP_SABERTHROW,2|FP_BLIND,1
 	attributes		MB_ATT_FORCEBLOCK,1|MB_ATT_DEFLECT,2|MB_ATT_FORCEFOCUS,2|MB_ATT_GUN_DEFENSE,1|MB_ATT_FP_SABER_DEFENSE,2|MB_ATT_LIGHTS_BEACON
 	
 	basespeed		230
@@ -21,9 +21,10 @@ ClassInfo
 	MBClass		MB_CLASS_JEDI
 	classflags CFL_NOPICKUPS
 
-	
+	special1	EAS_FP_SABERTHROW
 	special2	EAS_MELEE
-	special3 EAS_FP_PROTECT
+	special3	EAS_FP_PROTECT
+	special4	EAS_FP_BLIND
 	
 	
 	classNumberLimit	1
@@ -70,14 +71,16 @@ Aggressive support that can protect others from physical harm whilst being vulne
 -- Slap ^3[CS2]
 
 ^5Force Powers:
-- Jump (2)
-- Push (2)
+- Jump (3)
+- Push (3)
 - Pull (1)
 - Sense (1) 
 - Protect (1) ^3[CS3]
+- Blind (1) ^3[CS4]
 
 ^8Attributes:
 - Force Block (1)
 - Force Focus (2)
 ^7- ^3*^7Light's Beacon (Shares Force Powers with a ^7targeted/nearby ally)
+
 - 200% slower skill CD"

--- a/z_MBLegends/ext_data/mb2/character/h10_JTradition.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h10_JTradition.mbch
@@ -34,26 +34,19 @@ ClassInfo
 	saber1			saber_jocasta
 	sabercolor		4
 
-	saber1_1			saber_luminara
+	saber1_1			depa
 	sabercolor_1		3
-
-	saber1_2			depa
-	sabercolor_2		3
 	
-	saber1_3			saber_depa_tcw
-	sabercolor_3		3
+	saber1_2			saber_depa_tcw
+	sabercolor_2		3
 	
 	model    	 "JocastaNu"
 	skin		 	"default"
 	uishader  	"models/players/JocastaNu/mb2_icon_default"
-	
-	model_1		"luminara"
-	skin_1		"default"
-	uishader_1	"models/players/luminara/mb2_icon_default"
-	
-	model_2		"sabe" 					
-	skin_2		"depabillaba"					
-	uishader_2	"models/players/sabe/mb2_icon_depabillaba"
+		
+	model_1		"sabe" 					
+	skin_1		"depabillaba"					
+	uishader_1	"models/players/sabe/mb2_icon_depabillaba"
 	
 	//respawncustomtime  50000	
 }

--- a/z_MBLegends/ext_data/mb2/teamconfig/LEG_Good.mbtc
+++ b/z_MBLegends/ext_data/mb2/teamconfig/LEG_Good.mbtc
@@ -112,4 +112,6 @@ SubclassesForClass6
 	Subclass8	"h10_JApostate"
 	Subclass9	"h10_Rosh"
 	Subclass10	"h10_Grogu"
+	Subclass11	"h10_JKindredProtect"
+	Subclass12	"h10_JKindredAbsorb"
 }


### PR DESCRIPTION
Two jedi classes specifically meant to be played in tandem, weak on their own but strong together. Both of these classes utilize lights beacon and protect/absorb with a 200% longer skilltimer to prevent constantly having their buffs on, they do have 120hp and fp though to give them a small edge because of their otherwise lackluster kit.
I removed the Barriss/Luminara models/sabers from Jedi Healer/Traditionalist respectively as the duo classes utilize them.

Notable Overview:

- Jedi Kindred (Absorb) has pull 2, blaster defense 2, and 10% more BP whilst the rest of their kit is level 1.
- Jedi Kindred (Protect) has push 2, saber defense 2, and 10% more AP whilst the rest of their kit is level 1.