### PR TITLE
[community class] maul mando dual spec

### DIFF
--- a/z_MBLegends/ext_data/mb2/character/v5_MaulMando.mbch
+++ b/z_MBLegends/ext_data/mb2/character/v5_MaulMando.mbch
@@ -1,234 +1,252 @@
-//Siege class def file
-
 ClassInfo
 {
-	name			"v5_MaulMando"
-	MBClass		MB_CLASS_MANDALORIAN
-	classNumberLimit		2
-	weapons			WP_MELEE|WP_SABER|WP_FIRE_NADE
-	
-	WP_EE3Flags 		  HELD_ALTRELOAD
-	WP_MandoPistolFlags HELD_ALTRELOAD
-	WP_A280Flags		HELD_ALTRELOAD
-	WP_MinigunFlags	HELD_FLAME|HELD_DISRUPTIFY|HELD_ALTRELOAD|HELD_KNOCKBACK|HELD_STUN
-	
-	attributes	MB_ATT_JETPACK|MB_ATT_GUN_DEFENSE,3|MB_ATT_FP_SABER_DEFENSE,0|MB_ATT_WRISTLASER|MB_ATT_WOOKIEE_FURY,3|MB_ATT_ROCKET,1|MB_ATT_AMMO,3|MB_ATT_WOOKIE_STRENGTH,1|MB_ATT_DEXTERITY,3|MB_ATT_FUEL,3|MB_ATT_BESKAR,2|MB_ATT_TRACKING_BEACON|MB_ATT_DEFLECT,0|MB_ATT_FIRE_GRENADES,1
-	
-	forcepowers   FP_RAGE,3
-	
-	maxhealth	80
-	maxarmor		80
-	
-	saberMaxChain 1
-	saberDamage	60
-	saberstyle	SS_TAVION
-	saber1	energyshield_leg
-	APmultiplier 	0.3
-	BPmultiplier 	0.3
-	ASmultiplier 	1.3
-	
-	speed  1.03
-	
-	gloatAnim BOTH_VICTORY_FAST
-	flourishAnim BOTH_VICTORY_FAST
-	model	"deathwatch"
-	skin		"mauldalorian"
-	uishader "models/players/deathwatch/mb2_icon_mauldalorian"
-	uioverlay "gfx/icons/aerial"
-	modelscale  1.04
-
-	resource RESOURCE_RAGE 
-	forcepool	150
-	resourceRegenCap 	50
-    resourceRegenAmount 2
-    resourceRegenRate 750
-
-	special1 EAS_HI_ROCKET
-
-	special3 EAS_HI_DEX
-	special4 EAS_FP_RAGE
-	
-	WalkBackward 		BOTH_WALKBACK_DUAL
-	WalkForward BOTH_WALK_DUAL
-	isCustomBuild	1
-	mbPoints		6
-	
-	c_att_skill_0	MB_ATT_MANDO_PISTOL
-	c_att_names_0	"DX-13 Pistol(s) (WESTARs)"
-	c_att_ranks_0	2,0,1
-	c_att_descs_0 "20% faster RoF, 20% more velocity, 10% more FP DMG, 
-10% less DMG, Mag reload"
-	c_att_skill_1	MB_ATT_MINIGUN
-	c_att_names_1	"Vornax Cannon (Minigun)"
-	c_att_ranks_1	5,0
- c_att_descs_1 "Ignites/staggers/pushes on hit, 300% more DMG/FP DMG,
-788% slower RoF, 24% less velocity, 100% slower mag reload"
-	c_att_skill_2	MB_ATT_A280
-	c_att_names_2	"Concordian Rifle (A280)"
-	c_att_ranks_2	1,2,0
-	c_att_descs_2 "25% more FP DMG, 25% more velocity, 25% slower RoF, 
-40% slower mag reload"
-	c_att_skill_3	MB_ATT_EE3
-	c_att_names_3	"Sundari Repeater (EE-3)"
-	c_att_ranks_3	2,0,1
-	c_att_descs_3 "30% faster RoF, 20% more velocity, 40% slower mag reload"
-	c_att_skill_4 MB_ATT_RESPAWNS
-	c_att_names_4	"Reinforcement"
-	c_att_ranks_4 2
-
-	c_att_skill_5	MB_ATT_FLAMETHROWER
-	c_att_names_5	"Wrist Flamethrower ^3[CS2 TM]"
-	c_att_ranks_5	1
-	c_att_descs_5 "Toggle Melee Weapon Mode to swap Wrist Laser/Flamethrower"
+name "v5_MaulMando"
+MBClass MB_CLASS_MANDALORIAN
+classNumberLimit 2
+weapons WP_MELEE|WP_SABER|WP_FIRE_NADE
+WP_EE3Flags HELD_ALTRELOAD
+WP_MandoPistolFlags HELD_ALTRELOAD
+WP_A280Flags HELD_ALTRELOAD
+WP_MinigunFlags HELD_FLAME|HELD_DISRUPTIFY|HELD_ALTRELOAD|HELD_KNOCKBACK|HELD_STUN
+attributes MB_ATT_JETPACK|MB_ATT_GUN_DEFENSE,3|MB_ATT_FP_SABER_DEFENSE,0|MB_ATT_WRISTLASER|MB_ATT_THROWER_LIGHTNING|MB_ATT_WOOKIEE_FURY,2|MB_ATT_ROCKET,1|MB_ATT_AMMO,3|MB_ATT_WOOKIE_STRENGTH,1|MB_ATT_DEXTERITY,3|MB_ATT_FUEL,3|MB_ATT_BESKAR,2|MB_ATT_TRACKING_BEACON|MB_ATT_FIRE_GRENADES,1
+forcepowers FP_RAGE,3
+maxhealth 80
+rankhealth 120
+maxarmor 80
+rankarmor 120
+saberMaxChain 1
+saberDamage 60
+saberstyle SS_TAVION
+saber1 energyshield_leg
+APmultiplier 0.3
+BPmultiplier 0.3
+ASmultiplier 1.3
+speed 1.03
+gloatAnim BOTH_VICTORY_FAST
+flourishAnim BOTH_VICTORY_FAST
+WalkBackward BOTH_WALK_DUAL
+WalkForward BOTH_WALKBACK_DUAL
+model "deathwatch"
+skin "mauldalorian"
+uishader "models/players/deathwatch/mb2_icon_mauldalorian"
+uioverlay "gfx/icons/aerial"
+modelscale 1.04
+resource RESOURCE_RAGE
+forcepool 150
+resourceRegenCap 50
+resourceRegenAmount 3
+resourceRegenRate 750
+special1 EAS_HI_ROCKET
+special3 EAS_HI_DEX
+special4 EAS_FP_RAGE
+isCustomBuild 1
+mbPoints 7
+hasCustomSpec 2
+isOnlyOneSpec 1
+customSpecName_1 "Deathwatch Warrior"
+customSpecIcon_1 "gfx/menus/alpha/icon_weap_accuracy"
+customSpecDesc_1 ""
+customSpecName_2 "Mandalorian Besieger"
+customSpecIcon_2 "gfx/menus/alpha/icon_weap_expdamagesplash"
+customSpecDesc_2 ""
+c_att_skill_0 MB_ATT_THROWER
+c_att_names_0 "Kelborn Arc Caster"
+c_att_ranks_0 1
+c_att_descs_0 "+20% DMG, Electrifies targets on hit"
+c_att_skill_1 MB_ATT_MANDO_PISTOL
+c_att_names_1 "DX-13 Pistols(WESTARs)"
+c_att_ranks_1 2,0,1
+c_att_descs_1 "+20% RoF & velocity,+10% FP DMG,-10% DMG"
+c_att_skill_2 MB_ATT_A280
+c_att_names_2 "Concordian Rifle(A280)"
+c_att_ranks_2 1,2,0
+c_att_descs_2 "+25% FP DMG&velocity,40% slower mag reload"
+c_att_skill_3 MB_ATT_EE3
+c_att_names_3 "Sundari Repeater(EE-3)"
+c_att_ranks_3 2,0,1
+c_att_descs_3 "+20% RoF & velocity,40% slower mag reload"
+c_att_skill_4 MB_ATT_FLAMETHROWER
+c_att_names_4 "Wrist Flamethrower^3[CS2TM]"
+c_att_ranks_4 1
+c_att_descs_4 "Toggle Melee Weapon Mode to swap WL/Flamer"
+c_att_skill_5 MB_ATT_RESPAWNS
+c_att_names_5 "Reinforcement"
+c_att_ranks_5 2
+c_att_skill_15 MB_ATT_MINIGUN
+c_att_names_15 "Vornax Siege Cannon"
+c_att_ranks_15 0
+c_att_descs_15 "Ignites/staggers/pushes on direct hit,+300% DMG/FP DMG,200% slower RoF,100% slower mag reload"
+c_att_skill_16 MB_ATT_A280
+c_att_names_16 "Concordian Rifle(A280)"
+c_att_ranks_16 2,2,0
+c_att_descs_16 "+25% FP DMG & velocity,25% slower RoF,40% slower mag reload"
+c_att_skill_17 MB_ATT_FP_PROTECT
+c_att_names_17 "Protect"
+c_att_ranks_17 1,1
+c_att_skill_18 MB_ATT_BESKAR
+c_att_names_18 "Beskar"
+c_att_ranks_18 0,0,1
+c_att_skill_19 MB_ATT_FLAMETHROWER
+c_att_names_19 "Wrist Flamer^3[CS2TM]"
+c_att_ranks_19 1
+c_att_skill_20 MB_ATT_HEALTH
+c_att_names_20 "HP(120)"
+c_att_ranks_20 1
+c_att_skill_21 MB_ATT_ARMOUR
+c_att_names_21 "Armor(120)"
+c_att_ranks_21 1
 }
-WeaponInfo0
-{
-	WeaponToReplace	WP_SABER		
-	WeaponBasedOff	WP_SABER			
-	NewWorldModel	"models/weapons2/dummy/dummy.glm"  
-	NewViewModel	"models/weapons2/dummy/dummy.md3" 	  
-	Icon		"gfx/hud/w_icon_gunganshield"
-	WeaponName	"Mandalorian Personal Energy Shield" 
+WeaponInfo0{
+WeaponToReplace WP_SABER
+WeaponBasedOff WP_SABER
+NewWorldModel "models/weapons2/dummy/dummy.glm"
+NewViewModel "models/weapons2/dummy/dummy.md3"
+Icon "gfx/hud/w_icon_gunganshield"
+WeaponName "Mandalorian Personal Energy Shield"
 }
-WeaponInfo1
-{
-    WeaponToReplace	WP_MANDO_PISTOL   			
-    WeaponBasedOff	WP_MANDO_PISTOL  		
-	NewWorldModel		"models/weapons2/dx13_pistol/model_w.glm"
-	CorrectedWorldModel "models/weapons2/dx13_pistol/model_w.glm"
-	NewViewModel		"models/weapons2/dx13_pistol/model.md3"
-	Icon				"gfx/hud/w_icon_dx_13_dual"
-    WeaponName		"DX-13 Korda Six Shooters"   
-	MuzzleEffect		"Blaster/MuzzleFlash01Y"
-	AltMuzzleEffect	"Blaster/MuzzleFlash01Y"
-	MissileEffect		"Blaster/Shot02Y"
-	Missile3Effect	"Blaster/Shot03Y"
-	PowerupShotEffect	"Blaster/Shot04Y"
-	AltMissileEffect	"Blaster/Shot04Y"
-	FlashSound0		"sound/weapons/LPA_NN-14/fire.wav"
-	altFlashSound0	"sound/weapons/LPA_NN-14/alt_fire.wav"	
-	ChargeSound		"sound/weapons/leia_pistol/altcharge.mp3"
-	ChargeEffect		"gfx/effects/yellow_bryarFrontFlash" 
-	hasAnimOverrides 	1
-	animReadyRun 		BOTH_PAIN16   
-	animReady 		BOTH_PAIN16   
-	animReadyWalk 	BOTH_PAIN16    
-	animReadyNoAmmo BOTH_DUAL_PISTOLS_DRAW
-	animRunAttackR	BOTH_DUAL_PISTOLS_ATTACK_R
-	animRunAttackL	BOTH_DUAL_PISTOLS_ATTACK_L
-	animWalkAttackR	BOTH_DUAL_PISTOLS_ATTACK_R
-	animWalkAttackL	BOTH_DUAL_PISTOLS_ATTACK_L
-	animCharge	BOTH_DUAL_PISTOLS_READY
-	animStand 	BOTH_STAND9
-	customAmmo 800
-	clipsize	30
-	rateMod 	0.80
-	FPMult 	1.1
-	velocityMod 	1.20
-	damageMod 0.9
+WeaponInfo1{
+WeaponToReplace WP_MANDO_PISTOL
+WeaponBasedOff WP_MANDO_PISTOL
+NewWorldModel "models/weapons2/dx13_pistol/model_w.glm"
+CorrectedWorldModel "models/weapons2/dx13_pistol/model_w.glm"
+NewViewModel "models/weapons2/dx13_pistol/model.md3"
+Icon "gfx/hud/w_icon_dx_13_dual"
+WeaponName "DX-13 Korda Six Shooters"
+MuzzleEffect "Blaster/MuzzleFlash01Y"
+AltMuzzleEffect "Blaster/MuzzleFlash01Y"
+MissileEffect "Blaster/Shot02Y"
+Missile3Effect "Blaster/Shot03Y"
+PowerupShotEffect "Blaster/Shot04Y"
+AltMissileEffect "Blaster/Shot04Y"
+FlashSound0 "sound/weapons/LPA_NN-14/fire.wav"
+altFlashSound0 "sound/weapons/LPA_NN-14/alt_fire.wav"
+ChargeSound "sound/weapons/leia_pistol/altcharge.mp3"
+ChargeEffect "gfx/effects/yellow_bryarFrontFlash"
+hasAnimOverrides 1
+animReady BOTH_PAIN16
+animReadyWalk BOTH_PAIN16
+animReadyNoAmmo BOTH_DUAL_PISTOLS_DRAW
+animRunAttackR BOTH_DUAL_PISTOLS_ATTACK_R
+animRunAttackL BOTH_DUAL_PISTOLS_ATTACK_L
+animWalkAttackR BOTH_DUAL_PISTOLS_ATTACK_R
+animWalkAttackL BOTH_DUAL_PISTOLS_ATTACK_L
+animCharge BOTH_DUAL_PISTOLS_READY
+animStand BOTH_STAND9
+customAmmo 800
+clipsize 30
+rateMod 0.80
+FPMult 1.1
+velocityMod 1.2
+damageMod 0.9
 }
-WeaponInfo2
-{
-	WeaponToReplace		WP_MINIGUN
-	WeaponBasedOff		WP_MINIGUN
-	NewWorldModel		"models/weapons2/z6_rotary/model.glm"
-	NewViewModel		"models/weapons2/z6_rotary/rotary_cannon.md3"
-	NewHandsModel		"models/weapons2/z6_rotary/rotary_cannon_hand.md3"
-	NewBarrelModel		"models/weapons2/z6_rotary/rotary_cannon_barrel.md3"
-	MuzzleEffect  	"Blaster/MuzzleFlash01R"
-	altMuzzleEffect  "Blaster/MuzzleFlash01R"
-	MissileEffect 		"Blaster/Shot04R"
-	missileMissEffect 	"effects/Grenades/EXP_BaseThermal"
-	MissileHitHumanEffect	"effects/Grenades/EXP_BaseThermal"
-	MissileHitDroidEffect 	"effects/Grenades/EXP_BaseThermal"
-	FlashSound0	"sound/weapons/MWC-35c/fire.wav"
-	isMinigun 1
-	Icon	 "gfx/hud/w_icon_rotary_cannon"
-	WeaponName	"Vornax Rotary Siege Cannon"
-	FPMult	4
-	rateMod 8.88
-	damageMod 4
-	velocityMod	.76
-	ReloadTimeModifier 2
-	clipsize	10
-	customAmmo	350
+WeaponInfo2{
+WeaponToReplace WP_MINIGUN
+WeaponBasedOff WP_MINIGUN
+NewWorldModel "models/weapons2/z6_rotary/model.glm"
+NewViewModel "models/weapons2/z6_rotary/rotary_cannon.md3"
+NewHandsModel "models/weapons2/z6_rotary/rotary_cannon_hand.md3"
+NewBarrelModel "models/weapons2/z6_rotary/rotary_cannon_barrel.md3"
+MuzzleEffect "DW_Cannon/muzzleflash"
+altMuzzleEffect "DW_Cannon/muzzleflash"
+MissileEffect "Blaster/Shot04R"
+missileMissEffect "effects/Grenades/EXP_BaseThermal"
+MissileHitHumanEffect "effects/Grenades/EXP_BaseThermal"
+MissileHitDroidEffect "effects/Grenades/EXP_BaseThermal"
+FlashSound0 "sound/weapons/MWC-35c/fire.wav"
+isMinigun 1
+Icon "gfx/hud/w_icon_rotary_cannon"
+WeaponName "Vornax Rotary Siege Cannon"
+FPMult	4
+rateMod 8
+damageMod 4
+velocityMod	.76
+ReloadTimeModifier 2
+clipsize	12
+customAmmo 600
 }
-WeaponInfo3
-{
-	WeaponToReplace	WP_A280
-	WeaponBasedOff	WP_A280
-	NewWorldModel		"models/weapons2/kotor_drifle/kotor_drifle_w.glm"
-	NewViewModel		"models/weapons2/kotor_drifle/kotor_drifle.md3"
-	Icon				"gfx/hud/w_icon_kotor_drifle"
-	WeaponName		"Concordian Battle Rifle"
-	MuzzleEffect		"Blaster/MuzzleFlash01R"
-	AltMuzzleEffect	"Blaster/MuzzleFlash01R"
-	MissileEffect		"blaster/Shot03R"
-	AltMissileEffect 	"blaster/Shot03R"
-	FlashSound0 		"sound/weapons/EL-16/fire.wav"
-	FlashSound1 		"sound/weapons/EL-16/fire.wav"
-	FlashSound2 		"sound/weapons/EL-16/fire.wav"
-	FlashSound3 		"sound/weapons/EL-16/fire.wav"
-	AltFlashSound0  	"sound/weapons/EL-16/alt_fire.wav"
-	AltFlashSound1  	"sound/weapons/EL-16/alt_fire.wav"
-	AltFlashSound2  	"sound/weapons/EL-16/alt_fire.wav"
-	AltFlashSound3  	"sound/weapons/EL-16/alt_fire.wav"
-	customammo 	800
-	clipsize 80
-	FPMult	1.25
-	ReloadTimeModifier 1.4
-	rateMod 		1.25
-	velocityMod 	1.25
+WeaponInfo3{
+WeaponToReplace WP_A280
+WeaponBasedOff WP_A280
+NewWorldModel "models/weapons2/kotor_drifle/kotor_drifle_w.glm"
+NewViewModel "models/weapons2/kotor_drifle/kotor_drifle.md3"
+Icon "gfx/hud/w_icon_kotor_drifle"
+WeaponName "Concordian Battle Rifle"
+MuzzleEffect "Blaster/MuzzleFlash01R"
+AltMuzzleEffect "Blaster/MuzzleFlash01R"
+MissileEffect "blaster/Shot10R"
+AltMissileEffect "blaster/Shot03R"
+FlashSound0 "sound/weapons/EL-16/fire.wav"
+FlashSound1 "sound/weapons/EL-16/fire.wav"
+FlashSound2 "sound/weapons/EL-16/fire.wav"
+FlashSound3 "sound/weapons/EL-16/fire.wav"
+AltFlashSound0 "sound/weapons/EL-16/alt_fire.wav"
+AltFlashSound1 "sound/weapons/EL-16/alt_fire.wav"
+AltFlashSound2 "sound/weapons/EL-16/alt_fire.wav"
+AltFlashSound3 "sound/weapons/EL-16/alt_fire.wav"
+customammo 800
+clipsize 80
+FPMult 1.25
+ReloadTimeModifier 1.4
+velocityMod 1.25
 }
-WeaponInfo4 
-{
-    WeaponToReplace	WP_EE3
-    WeaponBasedOff   WP_EE3
-    NewWorldModel		"models/weapons2/cp-50_repeater/cp-50_repeater_w.glm"  
-    NewViewModel		"models/weapons2/cp-50_repeater/cp-50_repeater.md3"
-    Icon				"gfx/hud/w_icon_cp-50_repeater"
-    WeaponName			"Sundari Pattern-Repeater"    
-	MuzzleEffect		"Blaster/MuzzleFlash01Y"
-	AltMuzzleEffect	"Blaster/MuzzleFlash01Y"
-	MissileEffect		"Blaster/Shot02Y"
-	Missile3Effect	"Blaster/Shot03Y"
-	PowerupShotEffect	"Blaster/Shot04Y"
-	AltMissileEffect	"Blaster/Shot04Y"
-	customAmmo 	800
-	clipsize		32
-	//FPMult 	1.1
-	ReloadTimeModifier 	1.4
-	rateMod 			0.7
-	velocityMod 		1.2
+WeaponInfo4{
+WeaponToReplace WP_EE3
+WeaponBasedOff WP_EE3
+NewWorldModel "models/weapons2/cp-50_repeater/cp-50_repeater_w.glm"
+NewViewModel "models/weapons2/cp-50_repeater/cp-50_repeater.md3"
+Icon "gfx/hud/w_icon_cp-50_repeater"
+WeaponName "Sundari Pattern-Repeater"
+MuzzleEffect "Blaster/MuzzleFlash01Y"
+AltMuzzleEffect "Blaster/MuzzleFlash01Y"
+MissileEffect "Blaster/Shot02Y"
+Missile3Effect "Blaster/Shot03Y"
+PowerupShotEffect "Blaster/Shot04Y"
+AltMissileEffect "Blaster/Shot04Y"
+customAmmo 1000
+clipsize 32
+ReloadTimeModifier 1.4
+rateMod 0.8
+velocityMod 1.2
 }
-description	"Mandalorian Super Commando  
-
+WeaponInfo5{
+WeaponToReplace WP_THROWER
+WeaponBasedOff WP_THROWER
+NewWorldModel "models/weapons2/dummyblaster/model.glm"
+NewViewModel "models/weapons2/dummy/dummy.md3"
+Icon "gfx/marvel/maghand"
+WeaponName "Kelborn Arc Caster"
+clipsize 50
+customammo 600
+hasAnimOverrides 1
+animReady BOTH_FORCE_2HANDEDLIGHTNING_START
+animReadyWalk BOTH_FORCE_2HANDEDLIGHTNING_START
+animReadyNoAmmo BOTH_FORCE_2HANDEDLIGHTNING
+animStand BOTH_FORCE_2HANDEDLIGHTNING_START
+animAttack BOTH_MAND_FLAME_READY
+animAttackWalk BOTH_MAND_FLAME_READY
+animReadyRun BOTH_FORCE_2HANDEDLIGHTNING_START
+animAttackRun BOTH_MAND_FLAME_READY
+}
+description "Mandalorian Super Commando[Mandalorian]
 Enforcers with brutal burst fire/area control.
-
 ^2Weaponry:
-- Melee
-- Mandalorian Personal Energy Shield (Cyan Saber)
--- Saber Defense (0)
--- Blaster Defense (3)
--- 150% more KB
--- 50% less DMG
--- 12% less reach
--- 66% more radius
-- Fire Grenade (1)
-
+-Melee
+-Personal Energy Shield(Cyan Saber)
+--Saber Defense/Deflect(0)
+--Blaster Defense(3)
+--Slap^3[GB]
+-Fire Grenade(1)
 ^5Powers:
-- Dark Rage (3) ^3[CS4]
-
+-Dark Rage(3)^3[CS4]
 ^8Attributes:
-- Fury (3)
--- Resource Regen: 2/.75s to 50
-- Strength (1)
-- Dexterity (3)
-- Beskar (2)
-- Tracking Beacon
-
+-Fury(2)
+--Rage Regen:3/s to 50
+-Strength(1)
+-Dex(3)
+-Beskar(2)
+-Tracking Beacon
 ^3Abilities:
-- Jetpack
-- Rocket ^3[CS1]
-- Wrist Laser ^3[CS2 Toggle Melee]
-- Dex Roll ^3[CS3]"
+-Jetpack
+-Rocket^3[CS1]
+-Wrist Laser^3[CS2TM]
+-Dex Roll^3[CS3]"

--- a/z_MBLegends/ext_data/mb2/character/v5_MaulMando.mbch
+++ b/z_MBLegends/ext_data/mb2/character/v5_MaulMando.mbch
@@ -24,8 +24,6 @@ ASmultiplier 1.3
 speed 1.03
 gloatAnim BOTH_VICTORY_FAST
 flourishAnim BOTH_VICTORY_FAST
-WalkBackward BOTH_WALK_DUAL
-WalkForward BOTH_WALKBACK_DUAL
 model "deathwatch"
 skin "mauldalorian"
 uishader "models/players/deathwatch/mb2_icon_mauldalorian"
@@ -64,7 +62,7 @@ c_att_descs_2 "+25% FP DMG&velocity,40% slower mag reload"
 c_att_skill_3 MB_ATT_EE3
 c_att_names_3 "Sundari Repeater(EE-3)"
 c_att_ranks_3 2,0,1
-c_att_descs_3 "+20% RoF & velocity,40% slower mag reload"
+c_att_descs_3 "+20% RoF & velocity,50% slower mag reload"
 c_att_skill_4 MB_ATT_FLAMETHROWER
 c_att_names_4 "Wrist Flamethrower^3[CS2TM]"
 c_att_ranks_4 1
@@ -183,7 +181,7 @@ AltFlashSound0 "sound/weapons/EL-16/alt_fire.wav"
 AltFlashSound1 "sound/weapons/EL-16/alt_fire.wav"
 AltFlashSound2 "sound/weapons/EL-16/alt_fire.wav"
 AltFlashSound3 "sound/weapons/EL-16/alt_fire.wav"
-customammo 800
+customammo 1000
 clipsize 80
 FPMult 1.25
 ReloadTimeModifier 1.4
@@ -202,9 +200,9 @@ MissileEffect "Blaster/Shot02Y"
 Missile3Effect "Blaster/Shot03Y"
 PowerupShotEffect "Blaster/Shot04Y"
 AltMissileEffect "Blaster/Shot04Y"
-customAmmo 1000
+customAmmo 800
 clipsize 32
-ReloadTimeModifier 1.4
+ReloadTimeModifier 1.5
 rateMod 0.8
 velocityMod 1.2
 }


### PR DESCRIPTION
as per https://github.com/MBII/TextAssets/pull/800

changes:
- dual specs. 1 for normal weaponry loadout and 1 for the vornax cannon
- vornax cannon trispec loadout
- vornax pointbuy has protect, beskar 3, HP and armor purchase, and an a280
- HP purchase to 120 HP
- armor purchase 120 armor
- vornax ammo increased from 350 to 600 and clip size increased by 2
- kelborn arc caster weapon to deathwatch loadout. it's a 1 point cost lightning thrower with some nice wrist blaster animations.

again, tested offline, works for me. if there's an issue with char limit its very likely just a github quirk and it works fine ingame