### PR TITLE
h7_RebSapper fixed inaccessible m5 launcher

### DIFF
--- a/z_MBLegends/ext_data/mb2/character/h7_RebSapper.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h7_RebSapper.mbch
@@ -118,11 +118,12 @@ WeaponInfo3
     NewViewModel   "models/weapons2/cw-w5/dc-15_ext.md3"
     Icon  "gfx/hud/w_icon_cw-w5g"
     WeaponName  "Pulse Grenade Launcher"
-    customAmmo -1
-    clipSize -1
+    customAmmo 2
     primFireEnabled  0
     hasAnimOverrides 1
-    animReadyNoAmmo TORSO_WEAPONREADY3
+    animReady TORSO_WEAPONREADY3
+    animReadyWalk TORSO_WEAPONREADY3
+    animReadyRun TORSO_WEAPONREADY3
     animAttackRun     BOTH_ATTACK3
     animAttack     BOTH_ATTACK3
     animAttackWalk  BOTH_ATTACK3


### PR DESCRIPTION
- fixed a bug where you couldn't swap to the m5 because it didn't technically have any ammo.