### PR TITLE
h7_RebSapper rework

### DIFF
--- a/z_MBLegends/ext_data/mb2/character/h7_RebSapper.mbch
+++ b/z_MBLegends/ext_data/mb2/character/h7_RebSapper.mbch
@@ -5,15 +5,14 @@ MBClass MB_CLASS_ELITETROOPER
 classNumberLimit 2
 extralives 1
 
-weapons WP_MELEE|WP_BLASTER_PISTOL|WP_CR2|WP_M5|WP_DET_PACK|WP_PULSE_NADE|WP_FRAG_NADE
-attributes MB_ATT_PISTOL,2|MB_ATT_CR2,2|MB_ATT_DET_PACK,3|MB_ATT_ARC_RIFLE_GRENADELAUNCHER,2|MB_ATT_AMMO,3|MB_ATT_ASSEMBLE,2|MB_ATT_TRACKING_BEACON|MB_ATT_DEXTERITY,1|MB_ATT_FRAGS,1|MB_ATT_DRONE,1|MB_ATT_STIMPACK,1
+weapons WP_MELEE|WP_BLASTER_PISTOL|WP_DET_PACK|WP_PULSE_NADE|WP_FRAG_NADE
+attributes MB_ATT_PISTOL,2|MB_ATT_DET_PACK,3|MB_ATT_ARC_RIFLE_GRENADELAUNCHER,3|MB_ATT_AMMO,3|MB_ATT_ASSEMBLE,2|MB_ATT_TRACKING_BEACON|MB_ATT_DEXTERITY,1|MB_ATT_FRAGS,1|MB_ATT_DRONE,1|MB_ATT_STIMPACK,1
 
-forcepowers FP_LIGHTNING,1|FP_PULL,1
+forcepowers FP_LIGHTNING,1|FP_SEE,1
 
 resource RESOURCE_FUEL
 forcepool 65
 forceregen 1
-skilltimermod 3
 
 resourceRegenRate 1000
 resourceRegenAmount 5
@@ -38,7 +37,6 @@ knockbackTaken 1.1
 damageGiven 1.3 //IMPORTANT: This is to increase lightning and detpack damage by 30%. Set all other weapons' damageMod to the inverse, 1/damageGiven. (1/1.3 = 0.77)
 WP_MeleeFlags HELD_LOWDAMAGE|HELD_TRACKING
 WP_FragNadeFlags HELD_TRACKING
-WP_DetPackFlags HELD_KNOCKBACK
 rateOfFire_Melee    .8
 
 modelscale 1.02
@@ -55,6 +53,26 @@ special4 EAS_FP_LIGHTNING
 
 flourishAnim BOTH_ENGAGETAUNT
 //flourishAnim BOTH_MINDTRICK1
+
+isCustomBuild 1
+mbPoints 2
+
+c_att_skill_0   MB_ATT_CR2
+c_att_names_0   "E-11 Blaster Carbine"
+c_att_ranks_0   1,0
+c_att_descs_0   "10% more Velocity, 15% less Dmg"
+
+//required to be separate from a280, unfortunately,
+//because there is a bug that causes A280 level 2 to disable the Grenade Launcher..
+c_att_skill_1   MB_ATT_WESTARM5
+c_att_names_1   "Pulse Grenade Launcher"
+c_att_ranks_1   1
+c_att_descs_1   "25% faster RoF, Sec only"
+
+c_att_skill_2   MB_ATT_A280
+c_att_names_2   "A280 Blaster Rifle"
+c_att_ranks_2   2,0
+c_att_descs_2   "20% less Dmg, Secretly Scoped"
 }
 
 WeaponInfo0
@@ -85,7 +103,7 @@ MuzzleEffect "Blaster/MuzzleFlash01R"
 MissileEffect "Blaster/Shot02R"
 damageMod 0.85
 velocityMod 1.10
-customAmmo 360
+customAmmo 420
 clipSize 60
 }
 
@@ -117,7 +135,7 @@ WeaponInfo3
     NewViewModel   "models/weapons2/cw-w5/dc-15_ext.md3"
     Icon  "gfx/hud/w_icon_cw-w5g"
     WeaponName  "Pulse Grenade Launcher"
-    customAmmo 2
+    customAmmo 3
     primFireEnabled  0
     hasAnimOverrides 1
     animReady TORSO_WEAPONREADY3
@@ -126,17 +144,17 @@ WeaponInfo3
     animAttackRun     BOTH_ATTACK3
     animAttack     BOTH_ATTACK3
     animAttackWalk  BOTH_ATTACK3
-    ratemod 0.35
+    ratemod 0.75
 }
 
 WeaponInfo4
 {
 WeaponToReplace WP_FRAG_NADE
 WeaponBasedOff WP_FRAG_NADE
-	NewWorldModel				"models/weapons2/thermal/thermal_w.glm"
-	NewViewModel				"models/weapons2/thermal/thermal.md3"
-	NewHandsModel				"models/weapons2/thermal/thermal_hand.md3"
-	Icon							"gfx/hud/w_thermal_grenade"
+NewWorldModel               "models/weapons2/thermal/thermal_w.glm"
+NewViewModel                "models/weapons2/thermal/thermal.md3"
+NewHandsModel               "models/weapons2/thermal/thermal_hand.md3"
+Icon                            "gfx/hud/w_thermal_grenade"
 WeaponName  "Tracker Grenade"
 MissileModel "models/weapons2/thermal/thermal_proj.md3"
 MissileEffect   "effects/flechette/alt_shot" 
@@ -144,14 +162,25 @@ MissileMissEffect   "slime_explosion_new"
 //FlashSound0 "sound/effects/woosh8.mp3"
 altFireEnabled 0
 damageMod 0.01
-	hasAnimOverrides 1
-	animReadyRun BOTH_THERMAL_READY2
-	animReady BOTH_THERMAL_READY2
-	animReadyWalk BOTH_THERMAL_READY2
-	animReadyNoAmmo BOTH_THERMAL_READY2
-	animAttackRun BOTH_THERMAL_THROW2
-	animAttack BOTH_THERMAL_THROW2
-	animAttackWalk BOTH_THERMAL_THROW2
+    hasAnimOverrides 1
+    animReadyRun BOTH_THERMAL_READY2
+    animReady BOTH_THERMAL_READY2
+    animReadyWalk BOTH_THERMAL_READY2
+    animReadyNoAmmo BOTH_THERMAL_READY2
+    animAttackRun BOTH_THERMAL_THROW2
+    animAttack BOTH_THERMAL_THROW2
+    animAttackWalk BOTH_THERMAL_THROW2
+}
+
+WeaponInfo5
+{
+WeaponToReplace WP_A280
+WeaponBasedOff WP_A280
+NewWorldModel "models/weapons2/a280/a280_w.glm"
+NewViewModel "models/weapons2/a280/a280.md3"
+Icon "gfx/hud/w_icon_a280"
+WeaponName "A280 Blaster Rifle"
+damageMod 0.8
 }
 
 ForceInfo0
@@ -165,11 +194,11 @@ LoopSound null
 
 ForceInfo1
 {
-ForceToReplace FP_PULL
-Icon "gfx/forcepowers/push"
-ForcePowerName "Magna-Glove"
-HandShader "gfx/effects/dekashield2"
-StartSound "sound/effects/woosh7.mp3"
+ForceToReplace FP_SEE
+Icon "gfx/forcepowers/radar"
+ForcePowerName "Radar Scanner"
+StartSound "sound/ambience/kotor/console08.mp3"
+LoopSound "sound/ambience/cp_02_lp.wav"
 }
 
 description "Rebel Sapper 
@@ -182,23 +211,16 @@ description "Rebel Sapper
 -- 20% faster RoF
 - DL-44 Blaster Pistol (2)
 -- 20% less Dmg
-- E-11 Blaster Carbine (CR-2 2)
--- 10% more Velocity
--- 15% less Dmg
-- Pulse Grenade Launcher (M5)
--- 65% faster RoF
--- Sec only
 - Tracker Grenade (1) (Frag)
 -- Tracks on hit
 -- 99.9% less Dmg
 -- Prim only
-- Pulse Grenades (2)
+- Pulse Grenades (3)
 - Det Packs (3)
--- Pushes on det
 -- 40% faster RoF
 
 ^5Powers:
-- Magna-Glove (Pull 1)
+- Radar Scanner (Sense 1)
 - Wrist Shocker (Lightning 1) ^3[CS4]
 
 ^6Inventory:
@@ -209,7 +231,6 @@ description "Rebel Sapper
 - Reinforcement (1)
 - 15% faster Hacking
 - 10% more Kb Taken
-- 200% slower Skill Cd
 - Resource Regen: 5/s
 - Dexterity (1)
 - Armor Regen: 2/s to 20


### PR DESCRIPTION
Changelog:
- added A280 (2) as a point-buy alternative to CR-2 (2)
- re-added Sense (1)
- removed Pull (1)
- Pulse Nade ammo 2->3
- CR-2 Ammo 360->420
- Nade Launcher RoF 0.35->0.75 since pull gimmick is gone
- skilltimerMod 3->1 since pull is gone
- removed HELD_KNOCKBACK from Det Packs

Notes:
Nade Launcher is, for now, a point-buy that is mutually exclusive with A280 since there's a bug that causes A280 (2) to disable the GL and make it scoped.
In general, sapper felt like she had the power level of a 3-life but with only 2 lives. Since the previous rework, she has seen less play. There was very little reason to pick sapper over other 2-lives, so sense + a couple buffs should make her more useful again!  The re-addition of sense aims to help her stay alive despite being somewhat squishy.  Pulse nade ammo buffed to give her some more 2-life power, the launcher RoF was slowed anyways so this should be fine. A280 is an option now so sapper can be viable on more maps or in situations where the enemies are far away. For example, nobody wants to use a CR-2 on geonosian arena. So a280 is there now. Held_knockback on the det pack was too much; will add it back if detpack damage is ever defaulted to 1.0x for any reason. Magnet pull felt out of place, better to make that unique for Sec Droid.
