### PR TITLE
humanoid/SBD animevents update

### DIFF
--- a/MBAssets3/models/players/sbd/animevents.cfg
+++ b/MBAssets3/models/players/sbd/animevents.cfg
@@ -1,59 +1,100 @@
 UPPEREVENTS
 {
-	BOTH_MELEE1_BLASTER		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/ArmBash.mp3                 0 0 0
+	BOTH_MELEE1_BLASTER		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/ArmBash.mp3        0 0 0
 
-	BOTH_DEATH1    	     		AEV_SOUNDCHAN   	21 	CHAN_AUTO	sound/weapons/impacts/hit25.wav       0 0 0
-	BOTH_DEATH1    	     		AEV_SOUNDCHAN   	19 	CHAN_AUTO	sound/weapons/explosions/debris1.wav  0 0 0
-	BOTH_DEATH1    	     		AEV_SOUNDCHAN   	38 	CHAN_AUTO	sound/effects/metal_bounce.mp3        0 0 0
-	BOTH_DEATH1			AEV_EFFECT 		20 	sparks/spark_explosion.efx		*chestg		0
 	BOTH_DEATH1			AEV_EFFECT 		1 	sparks/electric.efx		*chestg		0
 	BOTH_DEATH1			AEV_EFFECT 		1 	sparks/bluesparks_w_sound	*chestg		0
+	BOTH_DEATH1   AEV_SOUNDCHAN 19 	CHAN_AUTO	sound/weapons/explosions/debris1.wav  0 0 0
+	BOTH_DEATH1			AEV_EFFECT 		 20 	sparks/spark_explosion.efx		*chestg		0
+	BOTH_DEATH1   AEV_SOUNDCHAN 21 	CHAN_AUTO	sound/weapons/impacts/hit25.wav       0 0 0
+	BOTH_DEATH1   AEV_SOUNDCHAN 38 	CHAN_AUTO	sound/effects/metal_bounce.mp3        0 0 0
 
-	BOTH_DEATH2    	     		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/weapons/impacts/hit25.wav       0 0 0
-	BOTH_DEATH2    	     		AEV_SOUNDCHAN   	8 	CHAN_AUTO	sound/effects/metal_bounce.mp3        0 0 0
 	BOTH_DEATH2			AEV_EFFECT 		1 	sparks/spark_explosion.efx		*chestg		0
 	BOTH_DEATH2			AEV_EFFECT 		1 	sparks/electric.efx		*chestg		0
 	BOTH_DEATH2			AEV_EFFECT 		1 	sparks/bluesparks_w_sound	*chestg		0
+	BOTH_DEATH2   AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/weapons/impacts/hit25.wav       0 0 0
+	BOTH_DEATH2   AEV_SOUNDCHAN   8 	CHAN_AUTO	sound/effects/metal_bounce.mp3        0 0 0
 
-	BOTH_DEATH3    	     		AEV_SOUNDCHAN   	10 	CHAN_AUTO	sound/SBD/droid_powerdown.wav         0 0 0
 	BOTH_DEATH3			AEV_EFFECT 		1 	sparks/electric.efx		*chestg		0
 	BOTH_DEATH3			AEV_EFFECT 		1 	sparks/bluesparks_w_sound	*chestg		0
-	
-		BOTH_MELEE1  		AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+	BOTH_DEATH3   AEV_SOUNDCHAN   10 	CHAN_AUTO	sound/SBD/droid_powerdown.wav         0 0 0
+
+	BOTH_MELEE1  	AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
 	BOTH_MELEE2 		AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN  1	CHAN_AUTO	sound/chars/nrsd/misc/pain100.mp3 0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   15 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   19 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   21 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   23 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   26 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   30 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   36 	CHAN_AUTO	sound/chars/turret/shutdown.mp3   0 0 0
+
+ BOTH_DUAL_TAUNT AEV_SOUNDCHAN  1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_DUAL_TAUNT AEV_SOUNDCHAN  15 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_DUAL_TAUNT AEV_SOUNDCHAN 30 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_DUAL_TAUNT AEV_SOUNDCHAN 36 	CHAN_AUTO	sound/chars/turret/shutdown.mp3   0 0 0
+
+
+ BOTH_ENGAGETAUNT AEV_SOUNDCHAN  1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_ENGAGETAUNT AEV_SOUNDCHAN 8 	CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN 1 	CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   15 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   21 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   27 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   34 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   46 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   56 CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   75	CHAN_AUTO	sound/chars/nrsd/misc/pain100.mp3 0 0 0
+
+ BOTH_SHOWOFF_DUAL AEV_SOUNDCHAN  1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_SHOWOFF_DUAL AEV_SOUNDCHAN  7 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_SHOWOFF_DUAL AEV_SOUNDCHAN  13 	CHAN_AUTO	sound/chars/turret/shutdown.mp3   0 0 0
 }
 
 LOWEREVENTS
 {
-	BOTH_WALK1       		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALK1       		  AEV_SOUNDCHAN  1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3	1 3 0
 	BOTH_WALK1_STRAFE_R		AEV_SOUNDCHAN		3	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
 	BOTH_WALK1_STRAFE_L		AEV_SOUNDCHAN		3	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALK_DUAL       		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALK1_BLASTER     		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK1   		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK_DUAL   		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK1_BLASTER     	AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUN1		        AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_BLASTER          	AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUNBACK1			AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUNBACK1_BLASTER      	AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUN_DUAL		        AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_STRAFE_R         	AEV_SOUNDCHAN   	4 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_STRAFE_L         	AEV_SOUNDCHAN   	4 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_WALK_DUAL       AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALK1_BLASTER   AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK1   		  AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK_DUAL   AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK1_BLASTER   AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUN1		              AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_BLASTER       	AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUNBACK1			         AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUNBACK1_BLASTER    AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUN_DUAL		          AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_STRAFE_R       AEV_SOUNDCHAN   	4 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_STRAFE_L       AEV_SOUNDCHAN   	4 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
 	
-	BOTH_WALK1       		AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALK1       		  AEV_SOUNDCHAN  13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3	1 3 0
 	BOTH_WALK1_STRAFE_R		AEV_SOUNDCHAN		10	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
 	BOTH_WALK1_STRAFE_L		AEV_SOUNDCHAN		10	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALK_DUAL       		AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALK1_BLASTER	     	AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK1   		AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK_DUAL   		AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK1_BLASTER    	AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUN1		        AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_WALK_DUAL       AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALK1_BLASTER	  AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK1   	  	AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK_DUAL   AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK1_BLASTER   AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUN1		              AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
 	BOTH_RUN1_BLASTER       	AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUNBACK1			AEV_SOUNDCHAN   	5  	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUNBACK1_BLASTER 		AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0	
-	BOTH_RUN_DUAL		        AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_STRAFE_R         	AEV_SOUNDCHAN   	11  	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_STRAFE_L         	AEV_SOUNDCHAN   	11  	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUNBACK1			         AEV_SOUNDCHAN   	5  	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUNBACK1_BLASTER 		 AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0	
+	BOTH_RUN_DUAL		          AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_STRAFE_R       AEV_SOUNDCHAN   	11  	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_STRAFE_L       AEV_SOUNDCHAN   	11  	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   59 	CHAN_AUTO	models/players/doomgalak/footstep4.wav   0 0 0
+
+BOTH_KNOCKDOWN1 AEV_SOUNDCHAN  1 CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+BOTH_KNOCKDOWN1 AEV_SOUNDCHAN  9 CHAN_AUTO	sound/midgar_v3/bike_impact.mp3 0 0 0
+BOTH_GETUP1 AEV_SOUNDCHAN  1 CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+BOTH_GETUP1 AEV_SOUNDCHAN  7 CHAN_AUTO	sound/SBD/SBDWalk%d.mp3	1 3 0
+BOTH_GETUP1 AEV_SOUNDCHAN  12 CHAN_AUTO	sound/SBD/SBDWalk%d.mp3	1 3 0
+BOTH_GETUP1 AEV_SOUNDCHAN  15 CHAN_AUTO	sound/chars/nrsd/misc/pain50.mp3 0 0 0
 }

--- a/z_MB_BaseAssets/models/players/SBD/animevents.cfg
+++ b/z_MB_BaseAssets/models/players/SBD/animevents.cfg
@@ -1,59 +1,100 @@
 UPPEREVENTS
 {
-	BOTH_MELEE1_BLASTER		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/ArmBash.mp3                 0 0 0
+	BOTH_MELEE1_BLASTER		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/ArmBash.mp3        0 0 0
 
-	BOTH_DEATH1    	     		AEV_SOUNDCHAN   	21 	CHAN_AUTO	sound/weapons/impacts/hit25.wav       0 0 0
-	BOTH_DEATH1    	     		AEV_SOUNDCHAN   	19 	CHAN_AUTO	sound/weapons/explosions/debris1.wav  0 0 0
-	BOTH_DEATH1    	     		AEV_SOUNDCHAN   	38 	CHAN_AUTO	sound/effects/metal_bounce.mp3        0 0 0
-	BOTH_DEATH1			AEV_EFFECT 		20 	sparks/spark_explosion.efx		*chestg		0
 	BOTH_DEATH1			AEV_EFFECT 		1 	sparks/electric.efx		*chestg		0
 	BOTH_DEATH1			AEV_EFFECT 		1 	sparks/bluesparks_w_sound	*chestg		0
+	BOTH_DEATH1   AEV_SOUNDCHAN 19 	CHAN_AUTO	sound/weapons/explosions/debris1.wav  0 0 0
+	BOTH_DEATH1			AEV_EFFECT 		 20 	sparks/spark_explosion.efx		*chestg		0
+	BOTH_DEATH1   AEV_SOUNDCHAN 21 	CHAN_AUTO	sound/weapons/impacts/hit25.wav       0 0 0
+	BOTH_DEATH1   AEV_SOUNDCHAN 38 	CHAN_AUTO	sound/effects/metal_bounce.mp3        0 0 0
 
-	BOTH_DEATH2    	     		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/weapons/impacts/hit25.wav       0 0 0
-	BOTH_DEATH2    	     		AEV_SOUNDCHAN   	8 	CHAN_AUTO	sound/effects/metal_bounce.mp3        0 0 0
 	BOTH_DEATH2			AEV_EFFECT 		1 	sparks/spark_explosion.efx		*chestg		0
 	BOTH_DEATH2			AEV_EFFECT 		1 	sparks/electric.efx		*chestg		0
 	BOTH_DEATH2			AEV_EFFECT 		1 	sparks/bluesparks_w_sound	*chestg		0
+	BOTH_DEATH2   AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/weapons/impacts/hit25.wav       0 0 0
+	BOTH_DEATH2   AEV_SOUNDCHAN   8 	CHAN_AUTO	sound/effects/metal_bounce.mp3        0 0 0
 
-	BOTH_DEATH3    	     		AEV_SOUNDCHAN   	10 	CHAN_AUTO	sound/SBD/droid_powerdown.wav         0 0 0
 	BOTH_DEATH3			AEV_EFFECT 		1 	sparks/electric.efx		*chestg		0
 	BOTH_DEATH3			AEV_EFFECT 		1 	sparks/bluesparks_w_sound	*chestg		0
-	
-		BOTH_MELEE1  		AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   1 4 0
-	BOTH_MELEE2 		AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   1 4 0
+	BOTH_DEATH3   AEV_SOUNDCHAN   10 	CHAN_AUTO	sound/SBD/droid_powerdown.wav         0 0 0
+
+	BOTH_MELEE1  	AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+	BOTH_MELEE2 		AEV_SOUNDCHAN   1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN  1	CHAN_AUTO	sound/chars/nrsd/misc/pain100.mp3 0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   15 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   19 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   21 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   23 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   26 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   30 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_FAST AEV_SOUNDCHAN   36 	CHAN_AUTO	sound/chars/turret/shutdown.mp3   0 0 0
+
+ BOTH_DUAL_TAUNT AEV_SOUNDCHAN  1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_DUAL_TAUNT AEV_SOUNDCHAN  15 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_DUAL_TAUNT AEV_SOUNDCHAN 30 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_DUAL_TAUNT AEV_SOUNDCHAN 36 	CHAN_AUTO	sound/chars/turret/shutdown.mp3   0 0 0
+
+
+ BOTH_ENGAGETAUNT AEV_SOUNDCHAN  1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_ENGAGETAUNT AEV_SOUNDCHAN 8 	CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN 1 	CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   15 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   21 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   27 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   34 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   46 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   56 CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   75	CHAN_AUTO	sound/chars/nrsd/misc/pain100.mp3 0 0 0
+
+ BOTH_SHOWOFF_DUAL AEV_SOUNDCHAN  1 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_SHOWOFF_DUAL AEV_SOUNDCHAN  7 	CHAN_AUTO	sound/chars/k2so/misc/k2so_melee.wav   0 0 0
+ BOTH_SHOWOFF_DUAL AEV_SOUNDCHAN  13 	CHAN_AUTO	sound/chars/turret/shutdown.mp3   0 0 0
 }
 
 LOWEREVENTS
 {
-	BOTH_WALK1       		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALK1       		  AEV_SOUNDCHAN  1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3	1 3 0
 	BOTH_WALK1_STRAFE_R		AEV_SOUNDCHAN		3	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
 	BOTH_WALK1_STRAFE_L		AEV_SOUNDCHAN		3	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALK_DUAL       		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALK1_BLASTER     		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK1   		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK_DUAL   		AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK1_BLASTER     	AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUN1		        AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_BLASTER          	AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUNBACK1			AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUNBACK1_BLASTER      	AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUN_DUAL		        AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_STRAFE_R         	AEV_SOUNDCHAN   	4 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_STRAFE_L         	AEV_SOUNDCHAN   	4 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_WALK_DUAL       AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALK1_BLASTER   AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK1   		  AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK_DUAL   AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK1_BLASTER   AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUN1		              AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_BLASTER       	AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUNBACK1			         AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUNBACK1_BLASTER    AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUN_DUAL		          AEV_SOUNDCHAN   	1 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_STRAFE_R       AEV_SOUNDCHAN   	4 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_STRAFE_L       AEV_SOUNDCHAN   	4 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
 	
-	BOTH_WALK1       		AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALK1       		  AEV_SOUNDCHAN  13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3	1 3 0
 	BOTH_WALK1_STRAFE_R		AEV_SOUNDCHAN		10	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
 	BOTH_WALK1_STRAFE_L		AEV_SOUNDCHAN		10	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALK_DUAL       		AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALK1_BLASTER	     	AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK1   		AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK_DUAL   		AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_WALKBACK1_BLASTER    	AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUN1		        AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_WALK_DUAL       AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALK1_BLASTER	  AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK1   	  	AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK_DUAL   AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_WALKBACK1_BLASTER   AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUN1		              AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
 	BOTH_RUN1_BLASTER       	AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUNBACK1			AEV_SOUNDCHAN   	5  	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
-	BOTH_RUNBACK1_BLASTER 		AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0	
-	BOTH_RUN_DUAL		        AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_STRAFE_R         	AEV_SOUNDCHAN   	11  	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
-	BOTH_RUN1_STRAFE_L         	AEV_SOUNDCHAN   	11  	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUNBACK1			         AEV_SOUNDCHAN   	5  	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0
+	BOTH_RUNBACK1_BLASTER 		 AEV_SOUNDCHAN   	14 	CHAN_AUTO	sound/SBD/SBDWalk%d.mp3		1 3 0	
+	BOTH_RUN_DUAL		          AEV_SOUNDCHAN   	13 	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_STRAFE_R       AEV_SOUNDCHAN   	11  	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+	BOTH_RUN1_STRAFE_L       AEV_SOUNDCHAN   	11  	CHAN_AUTO	sound/SBD/SBDStep%d.mp3		1 3 0
+
+ BOTH_VICTORY_DUAL AEV_SOUNDCHAN   59 	CHAN_AUTO	models/players/doomgalak/footstep4.wav   0 0 0
+
+BOTH_KNOCKDOWN1 AEV_SOUNDCHAN  1 CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+BOTH_KNOCKDOWN1 AEV_SOUNDCHAN  9 CHAN_AUTO	sound/midgar_v3/bike_impact.mp3 0 0 0
+BOTH_GETUP1 AEV_SOUNDCHAN  1 CHAN_AUTO	sound/interface/transition.mp3 0 0 0
+BOTH_GETUP1 AEV_SOUNDCHAN  7 CHAN_AUTO	sound/SBD/SBDWalk%d.mp3	1 3 0
+BOTH_GETUP1 AEV_SOUNDCHAN  12 CHAN_AUTO	sound/SBD/SBDWalk%d.mp3	1 3 0
+BOTH_GETUP1 AEV_SOUNDCHAN  15 CHAN_AUTO	sound/chars/nrsd/misc/pain50.mp3 0 0 0
 }

--- a/z_MB_BaseAssets/models/players/_humanoid/animevents.cfg
+++ b/z_MB_BaseAssets/models/players/_humanoid/animevents.cfg
@@ -1,733 +1,976 @@
-
 UPPEREVENTS
 {
- BOTH_A1_SPECIAL      AEV_SOUNDCHAN   1 CHAN_AUTO       *combat%d.mp3                               1 3  50
-	BOTH_A1_SPECIAL      AEV_SOUNDCHAN  24 CHAN_AUTO         sound/weapons/saber/saberhup%d.mp3       1 3  0
-	BOTH_A1_SPECIAL      AEV_SOUNDCHAN  34 CHAN_AUTO         sound/weapons/saber/saberhup%d.mp3       1 3  0
-	BOTH_A1_SPECIAL      AEV_SOUNDCHAN  41 CHAN_AUTO         sound/weapons/saber/saberhup%d.mp3       1 3  0
-	BOTH_A1_SPECIAL      AEV_SOUNDCHAN  47 CHAN_AUTO         sound/weapons/saber/saberhup%d.mp3       1 3  0
-	BOTH_A1_SPECIAL      AEV_SOUNDCHAN   8 CHAN_AUTO         sound/weapons/saber/saberhup%d.mp3       1 3  0
-	BOTH_A1_SPECIAL      AEV_SOUNDCHAN  15 CHAN_AUTO         sound/weapons/saber/saberhup%d.mp3       1 3  0
- BOTH_A2_SPECIAL      AEV_SOUNDCHAN   1  CHAN_AUTO        *combat%d.mp3                             1 3  50
-	BOTH_A2_SPECIAL      AEV_SOUNDCHAN  12 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A2_SPECIAL      AEV_SOUNDCHAN  20 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A2_SPECIAL      AEV_SOUNDCHAN  31 CHAN_AUTO         sound/weapons/saber/saberhup%d.mp3       1 3  0
-	BOTH_A2_SPECIAL      AEV_SOUNDCHAN  45 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
- BOTH_A2_STABBACK1    AEV_SOUNDCHAN   1  CHAN_AUTO        *combat%d.mp3                             1 3  50
-	BOTH_A2_STABBACK1    AEV_SOUNDCHAN  12 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A2_STABBACK1    AEV_SOUNDCHAN  31 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
- BOTH_A3_SPECIAL      AEV_SOUNDCHAN   1  CHAN_AUTO        *combat%d.mp3                             1 3  50
-	BOTH_A3_SPECIAL      AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberspin1.wav       0 0  0
-	BOTH_A3_SPECIAL      AEV_SOUNDCHAN   8 CHAN_AUTO         sound/weapons/saber/saberspin2.wav       0 0  0
-	BOTH_A3_SPECIAL      AEV_SOUNDCHAN  13 CHAN_AUTO         sound/weapons/saber/saberspin2.wav       0 0  0
-	BOTH_A3_SPECIAL      AEV_SOUNDCHAN  18 CHAN_AUTO         sound/weapons/saber/saberspin2.wav       0 0  0
-	BOTH_A3_SPECIAL      AEV_SOUNDCHAN  25 CHAN_AUTO         sound/weapons/saber/saberspin2.wav       0 0  0
-	BOTH_A3_SPECIAL      AEV_SOUNDCHAN  28 CHAN_AUTO        sound/weapons/saber/saberhup%d.wav        1 9  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  17 CHAN_AUTO        sound/weapons/saber/saberspin.wav         0 0  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  25 CHAN_AUTO        sound/weapons/saber/saberhup%d.wav        1 9  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  38 CHAN_AUTO        sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  50 CHAN_AUTO        sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  57 CHAN_AUTO        sound/weapons/saber/saberhup%d.wav        1 9  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  70 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  31 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  44 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A6_SABERPROTECT AEV_SOUNDCHAN  69 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
-	BOTH_A7_HILT		       AEV_SOUNDCHAN	  1 CHAN_AUTO	        *combat%d.mp3	                            1 3  50
- BOTH_A7_SOULCAL      AEV_SOUNDCHAN   1  CHAN_AUTO        *combat%d.mp3                             1 3  50
-	BOTH_A7_SOULCAL      AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  32 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  46 CHAN_AUTO         sound/weapons/saber/saberhup%d.mp3       1 3  0
-	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  59 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
- BOTH_ARIAL_LEFT      AEV_SOUNDCHAN  2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	          1 4  0
- BOTH_ARIAL_RIGHT     AEV_SOUNDCHAN  2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	          1 4  0
- BOTH_ATTACK_BACK     AEV_SOUNDCHAN  1  CHAN_AUTO        *combat%d.mp3                              1 3  50
-	BOTH_ATTACK_BACK     AEV_SOUNDCHAN  3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav        1 9  0
-	BOTH_ATTACK_BACK     AEV_SOUNDCHAN  14 CHAN_AUTO        sound/weapons/saber/saberhup%d.wav        1 9  0
-	BOTH_B6__R___        AEV_SOUNDCHAN  1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav        1 9  0
- BOTH_BOW             AEV_SOUNDCHAN  13 CHAN_AUTO        sound/player/footsteps/bare%d.mp3         1 9  0
- BOTH_CROUCHATTACKBACK1 AEV_SOUNDCHAN  1  CHAN_AUTO      *combat%d.mp3                              1 3  50
-	BOTH_CROUCHATTACKBACK1 AEV_SOUNDCHAN 8 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_CROUCHATTACKBACK1 AEV_SOUNDCHAN 22 CHAN_AUTO        sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_CYAN_DFA     AEV_SOUNDCHAN  	 1  CHAN_AUTO          *combat%d.mp3                             1 3  50
-	BOTH_CYAN_DFA     AEV_SOUNDCHAN  	 3  CHAN_AUTO          sound/weapons/saber/saberhup%d.wav       7 9  0
-	BOTH_CYAN_DFA     AEV_SOUNDCHAN  	14  CHAN_AUTO          sound/weapons/saber/saberhup%d.wav       7 9  0
-	BOTH_DODGE_BL					AEV_SOUNDCHAN   4 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3	1 4 0
-	BOTH_DODGE_BR					AEV_SOUNDCHAN   4 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3	1 4 0
-	BOTH_DODGE_FL					AEV_SOUNDCHAN   4 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3	1 4 0
-	BOTH_DODGE_FR					AEV_SOUNDCHAN   4 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3	1 4 0
-	BOTH_DODGE_L 					AEV_SOUNDCHAN   4 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3	1 4 0
-	BOTH_DODGE_R 					AEV_SOUNDCHAN   4 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3	1 4 0
-	BOTH_DUAL_TAUNT      AEV_SOUNDCHAN  11 CHAN_WEAPON    sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_DUAL_TAUNT      AEV_SOUNDCHAN  73 CHAN_AUTO      sound/weapons/saber/saberhup%d.mp3       1 3  0
- BOTH_ENGAGETAUNT     AEV_SOUNDCHAN   1  CHAN_AUTO	      sound/effects/cloth2.mp3			0 0  0
- //BOTH_ENGAGETAUNT     AEV_SOUNDCHAN   9  CHAN_AUTO     s/w/m/swing4.mp3         0 0 0
- //BOTH_ENGAGETAUNT     AEV_SOUNDCHAN  14  CHAN_AUTO     s/w/m/swing4.mp3         0 0 0
- BOTH_FLIP_ATTACK7 AEV_SOUNDCHAN 1 CHAN_AUTO        *combat%d.mp3                              1 3  50
-	BOTH_FLIP_LEFT  AEV_SOUNDCHAN  2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	          1 4  0
-	BOTH_FLIP_BACK1 AEV_SOUNDCHAN  2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	          1 4  0
-	BOTH_FLIP_BACK2 AEV_SOUNDCHAN  2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	          1 4  0
-	BOTH_FLIP_BACK3 AEV_SOUNDCHAN  2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	          1 4  0
-	BOTH_FJSS_TL_BR      AEV_SOUNDCHAN  16 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_FJSS_TL_BR      AEV_SOUNDCHAN  27 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_FJSS_TL_BR      AEV_SOUNDCHAN  54 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_FJSS_TR_BL      AEV_SOUNDCHAN  16 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_FJSS_TR_BL      AEV_SOUNDCHAN  27 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_FJSS_TR_BL      AEV_SOUNDCHAN  54 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_FORCELEAP2_T__B_ AEV_SOUNDCHAN 1  CHAN_AUTO         *combat%d.mp3                            1 3  50
-	BOTH_FORCELEAP2_T__B_ AEV_SOUNDCHAN 22 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav      1 9  0
- BOTH_FORCELONGLEAP_START AEV_SOUNDCHAN 1  CHAN_AUTO      *combat%d.mp3                            1 3  50
-	BOTH_GESTURE1        AEV_SOUNDCHAN  30 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  41 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  47 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  52 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  56 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  59 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  62 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  65 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  68 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
-	BOTH_GESTURE1        AEV_SOUNDCHAN  72 CHAN_AUTO         sound/weapons/saber/saberspinoff.wav     0 0  0
- BOTH_HAN_TAUNT AEV_SOUNDCHAN   6  CHAN_AUTO	             sound/effects/cloth2.mp3			0 0  0
- BOTH_HAN_TAUNT AEV_SOUNDCHAN   18  CHAN_AUTO	            sound/effects/cloth2.mp3			0 0  0
- BOTH_JUMPATTACK6     AEV_SOUNDCHAN   1  CHAN_AUTO        *combat%d.mp3                             1 3  50
-	BOTH_JUMPATTACK6     AEV_SOUNDCHAN   7 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPATTACK6     AEV_SOUNDCHAN  12 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPATTACK6     AEV_SOUNDCHAN  18 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPATTACK6     AEV_SOUNDCHAN  23 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPATTACK6     AEV_SOUNDCHAN  28 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPATTACK6     AEV_SOUNDCHAN  33 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPATTACK6     AEV_SOUNDCHAN  38 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
- BOTH_JUMPATTACK7     AEV_SOUNDCHAN   1 CHAN_AUTO         *combat%d.mp3                             1 3  50
-	BOTH_JUMPATTACK7     AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPATTACK7     AEV_SOUNDCHAN   5 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPATTACK7     AEV_SOUNDCHAN   9 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
- BOTH_JUMPFLIPSLASHDOWN1 AEV_SOUNDCHAN   1 CHAN_AUTO      *combat%d.mp3                             1 3  50
-	BOTH_JUMPFLIPSLASHDOWN1 AEV_SOUNDCHAN 13 CHAN_AUTO       sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_JUMPFLIPSTABDOWN AEV_SOUNDCHAN   1  CHAN_AUTO       *combat%d.mp3                             1 3  50
-	BOTH_JUMPFLIPSTABDOWN AEV_SOUNDCHAN  12 CHAN_AUTO        sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_K6_S6_TR        AEV_SOUNDCHAN   9 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_K6_S6_T_        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_KYLE_GRAB       AEV_SOUNDCHAN   9 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	         1 4  0
-	BOTH_KYLE_MISS       AEV_SOUNDCHAN   1 CHAN_AUTO         *land1.mp3                                0 0  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN   0 CHAN_AUTO         sound/movers/objects/objecthit.wav       0 0  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  10 CHAN_AUTO         *jump1.mp3                                0 0  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  25 CHAN_AUTO         sound/weapons/melee/punch%d.mp3          1 4  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  23 CHAN_AUTO         *land1.mp3                                0 0  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  49 CHAN_AUTO         sound/weapons/melee/punch%d.mp3          1 4  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  81 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	         1 4  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  86 CHAN_AUTO         sound/weapons/melee/punch%d.mp3          1 4  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  60 CHAN_AUTO         *jump1.mp3                                0 0  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  75 CHAN_AUTO         *land1.mp3                                0 0  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  87 CHAN_AUTO         *pain25.mp3                               0 0  0
-	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  52 CHAN_AUTO         *land1.mp3                                0 0  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN   0 CHAN_AUTO         sound/movers/objects/objecthit.wav       0 0  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  14 CHAN_AUTO         *jump1.mp3                                0 0  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  28 CHAN_AUTO         *pain25.mp3                               0 0  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  44 CHAN_AUTO         *combat%d.mp3                             1 3  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  62 CHAN_AUTO         *land1.mp3                                0 0  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  81 CHAN_AUTO         *combat%d.mp3                             1 3  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  49 CHAN_AUTO         sound/weapons/force/pull.mp3             0 0  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  85 CHAN_AUTO         sound/weapons/force/push.mp3             0 0  0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  91 CHAN_AUTO         *jump1.mp3                                0 0  0
-	BOTH_KYLE_PA_3       AEV_SOUNDCHAN   0 CHAN_AUTO         sound/movers/objects/objecthit.wav       0 0  0
-	BOTH_KYLE_PA_3       AEV_SOUNDCHAN  29 CHAN_AUTO         *taunt%d.mp3                              1 3  0
-	BOTH_KYLE_PA_3       AEV_SOUNDCHAN  55 CHAN_AUTO         *gloat%d.mp3                              1 3  0
-	BOTH_KYLE_PA_3       AEV_SOUNDCHAN  93 CHAN_AUTO         *land1.mp3                                0 0  0
-	BOTH_KYLE_PA_3       AEV_SOUNDCHAN 118 CHAN_AUTO         *jump1.mp3                                0 0  0
-	BOTH_KYLE_PA_3       AEV_SOUNDCHAN 140 CHAN_AUTO         *pain25.mp3                               0 0  0
-	BOTH_KYLE_PA_3       AEV_SOUNDCHAN 143 CHAN_AUTO         sound/weapons/force/push.mp3             0 0  0
- BOTH_LUNGE2_B__T_    AEV_SOUNDCHAN 1  CHAN_AUTO          *combat%d.mp3                             1 3  50
-	BOTH_MELEE1          AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3          1 4  0
-	BOTH_MELEE2          AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3          1 4  0
- BOTH_PALPATINE_DFA   AEV_SOUNDCHAN   5 CHAN_AUTO         sound/weapons/melee/swing%d.mp3          1 4  0
- BOTH_PALPATINE_DFA   AEV_SOUNDCHAN   10 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
- BOTH_PALPATINE_DFA   AEV_SOUNDCHAN   15 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
- BOTH_PALPATINE_DFA   AEV_SOUNDCHAN   20 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
- BOTH_PALPATINE_DFA   AEV_SOUNDCHAN   25 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN  25 CHAN_AUTO         *pain25.mp3                              0 0  0
-	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN  49 CHAN_AUTO         *pain50.mp3                              0 0  0
-	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN  85 CHAN_AUTO         *pain75.mp3                              0 0  0
-	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN   1 CHAN_AUTO         *land1.mp3                               0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN   2 CHAN_AUTO         *land1.mp3                               0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  35 CHAN_AUTO         *gasp.mp3                                0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  47 CHAN_AUTO         *pain50.mp3                              0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  65 CHAN_AUTO         *pain75.mp3                              0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  95 CHAN_AUTO         *pain100.mp3                             0 0  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN   1 CHAN_AUTO         *pushed%d.mp3                            1 3  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN   5 CHAN_AUTO         *jump1.mp3                               0 0  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  20 CHAN_AUTO         *land1.mp3                               0 0  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  35 CHAN_AUTO         *choke%d.mp3                             1 3  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  54 CHAN_AUTO         *choke%d.mp3                             1 3  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  73 CHAN_AUTO         *pushed%d.mp3                            1 3  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  77 CHAN_AUTO         *choke%d.mp3                             1 3  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  97 CHAN_AUTO         *pain75.mp3                              0 0  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN 116 CHAN_AUTO         *jump1.mp3                               0 0  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN 141 CHAN_AUTO         *pushed%d.mp3                            1 3  0
- BOTH_PULL_IMPALE_STAB AEV_SOUNDCHAN 1 CHAN_AUTO     *combat%d.mp3                                 1 3  50
- BOTH_PULL_IMPALE_STAB AEV_SOUNDCHAN  22 CHAN_AUTO   sound/weapons/saber/saberhup%d.wav           1 9  0
- BOTH_PULL_IMPALE_SWING AEV_SOUNDCHAN 1 CHAN_AUTO    *combat%d.mp3                                 1 3  50
- BOTH_PULL_IMPALE_SWING AEV_SOUNDCHAN   13 CHAN_AUTO sound/weapons/saber/saberhup%d.wav           1 9  0
-	BOTH_R6_TL_S6        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav      1 9  0
-	BOTH_R6__L_S6        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav      1 9  0
-	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN 110 CHAN_AUTO     sound/player/roll1.wav                  0 0  0
-	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN  25 CHAN_AUTO     *death%d.wav                             1 3 30
-	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN  64 CHAN_AUTO     *death%d.wav                             1 3  0
-	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN  88 CHAN_AUTO     *death%d.wav                             1 3 30
-	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN 100 CHAN_AUTO     *death%d.wav                             1 3 30
-	BOTH_ROLL_F		AEV_SOUNDCHAN	 1	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_ROLL_B 	AEV_SOUNDCHAN	 1	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_ROLL_L 	AEV_SOUNDCHAN	 1	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_ROLL_R 	AEV_SOUNDCHAN	 1	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
- BOTH_ROLL_STAB           AEV_SOUNDCHAN 1 CHAN_AUTO       *combat%d.mp3                             1 3  0
-	BOTH_S1_S7           AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_S1_S7           AEV_SOUNDCHAN   5 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_S6_S6_TR        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_S6_S6_T_        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_S6_S6__L        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_S7_S7_T_        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_S7_S7_T_        AEV_SOUNDCHAN   5 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SHOWOFF_DUAL    AEV_SOUNDCHAN  13 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
-	BOTH_SHOWOFF_DUAL    AEV_SOUNDCHAN   6 CHAN_WEAPON       sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_SHOWOFF_DUAL	   AEV_EFFECT  	 6 saber/saber_block.efx	*blade1		0
-	BOTH_SHOWOFF_DUAL	   AEV_EFFECT  	 8 saber/saber_block.efx	*blade1		0
-	BOTH_SHOWOFF_DUAL	   AEV_EFFECT 	10 saber/saber_block.efx	*blade1		0
-	BOTH_SHOWOFF_DUAL	   AEV_EFFECT 	12 saber/saber_block.efx	*blade1		0
-	BOTH_SHOWOFF_DUAL    AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/saber/saberblock2.mp3      0 0  0
-	BOTH_SHOWOFF_DUAL    AEV_SOUNDCHAN   8 CHAN_AUTO         sound/weapons/saber/saberblock5.mp3      0 0  0
-	BOTH_SHOWOFF_DUAL    AEV_SOUNDCHAN  10 CHAN_AUTO         sound/weapons/saber/saberblock2.mp3      0 0  0
-	BOTH_SHOWOFF_DUAL    AEV_SOUNDCHAN  12 CHAN_AUTO         sound/weapons/saber/saberblock4.mp3      0 0  0
-	BOTH_SHOWOFF_FAST    AEV_SOUNDCHAN   3 CHAN_WEAPON       sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_SHOWOFF_MEDIUM  AEV_SOUNDCHAN   7 CHAN_WEAPON       sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_SHOWOFF_MEDIUM  AEV_SOUNDCHAN  11 CHAN_WEAPON       sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_SHOWOFF_MEDIUM  AEV_SOUNDCHAN  15 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
-	BOTH_SHOWOFF_STAFF   AEV_SOUNDCHAN   5 CHAN_AUTO         sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_SHOWOFF_STAFF   AEV_SOUNDCHAN  26 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
-	BOTH_SHOWOFF_STRONG  AEV_SOUNDCHAN   1 CHAN_WEAPON       sound/weapons/saber/saberhup%d.mp3       1 3  0
-	BOTH_SHOWOFF_STRONG  AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_SHOWOFF_STRONG  AEV_SOUNDCHAN  10 CHAN_AUTO         sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_SHOWOFF_STRONG  AEV_SOUNDCHAN  15 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
- BOTH_SPINATTACK6     AEV_SOUNDCHAN   1  CHAN_AUTO         *combat%d.mp3                            1 3  50
-	BOTH_SPINATTACK6     AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK6     AEV_SOUNDCHAN   9 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK6     AEV_SOUNDCHAN  13 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK6     AEV_SOUNDCHAN  16 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK6     AEV_SOUNDCHAN  22 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK6     AEV_SOUNDCHAN  26 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK6     AEV_SOUNDCHAN  29 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK6     AEV_SOUNDCHAN  33 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
- BOTH_SPINATTACK7     AEV_SOUNDCHAN   1  CHAN_AUTO         *combat%d.mp3                            1 3  50
-	BOTH_SPINATTACK7     AEV_SOUNDCHAN  10 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK7     AEV_SOUNDCHAN  16 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK7     AEV_SOUNDCHAN  22 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK7     AEV_SOUNDCHAN  28 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK7     AEV_SOUNDCHAN  32 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_SPINATTACK7     AEV_SOUNDCHAN  37 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
- BOTH_STABDOWN        AEV_SOUNDCHAN   1  CHAN_AUTO     *combat%d.mp3                                1 3  50
- BOTH_STABDOWN_DUAL   AEV_SOUNDCHAN   1  CHAN_AUTO     *combat%d.mp3                                1 3  50
- BOTH_STABDOWN_STAFF  AEV_SOUNDCHAN   1  CHAN_AUTO     *combat%d.mp3                                1 3  50
-	BOTH_T6_BL_TL        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BL_TR        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BL_TR        AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_T6_BL_TR        AEV_SOUNDCHAN   7 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BL_TR        AEV_SOUNDCHAN  10 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BL_T_        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BL_T_        AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BL__R        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BL__R        AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_T6_BL__R        AEV_SOUNDCHAN   7 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BL__R        AEV_SOUNDCHAN  10 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BR_BL        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BR_TL        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BR_TL        AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BR__L        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_BR__L        AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_TL_BR        AEV_SOUNDCHAN   8 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_TL__R        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_TL__R        AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_T6_TL__R        AEV_SOUNDCHAN   7 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_TL__R        AEV_SOUNDCHAN  10 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_TR_BL        AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_TR_TL        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_TR_T_        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_T6_TR__L        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_T__BR        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_T__TL        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_T___L        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6_T___R        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__L_BR        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__L_BR        AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__L_T_        AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__L_T_        AEV_SOUNDCHAN   8 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__L__R        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__L__R        AEV_SOUNDCHAN   7 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__R_BL        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__R_BR        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__R_TL        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__R_TL        AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__R_TL        AEV_SOUNDCHAN  10 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__R_T_        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T6__R__L        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_BL_BR        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_BL_TR        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_BL__R        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_BR_T_        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_BR_T_        AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_BR__L        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_TL_BR        AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_TL_BR        AEV_SOUNDCHAN  10 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_TL_TR        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_TL__R        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_TR_BL        AEV_SOUNDCHAN   0 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_TR_TL        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_TR__L        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_T__BR        AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7_T__TR        AEV_SOUNDCHAN   1 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7__L_TR        AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7__R_TL        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7__R_T_        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_T7__R__L        AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_TUSKENATTACK1   AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/tusken_staff/swing%d.wav   1 4  0
-	BOTH_TUSKENATTACK2   AEV_SOUNDCHAN   6 CHAN_AUTO         sound/weapons/tusken_staff/swing%d.wav   1 4  0
-	BOTH_TUSKENATTACK3   AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/tusken_staff/swing%d.wav   1 4  0
-	BOTH_V6_TR_S6        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_V6_T__S6        AEV_SOUNDCHAN   3 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_VICTORY_DUAL    AEV_SOUNDCHAN  15 CHAN_AUTO         sound/weapons/saber/saberblock3.mp3      0 0  0
-	BOTH_VICTORY_DUAL	   AEV_EFFECT 15 saber/saber_block.efx *blade1	0
-	BOTH_VICTORY_DUAL	   AEV_EFFECT 16 saber/saber_block.efx *blade1	0
-	BOTH_VICTORY_DUAL	   AEV_EFFECT 17 saber/saber_block.efx *blade1	0
-	BOTH_VICTORY_DUAL	   AEV_EFFECT 18 saber/saber_block.efx *blade1	0
- BOTH_VICTORY_FAST    AEV_SOUNDCHAN   10  CHAN_AUTO	      sound/effects/cloth2.mp3			0 0  0
-	BOTH_VICTORY_MEDIUM  AEV_SOUNDCHAN   7 CHAN_WEAPON       sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_VICTORY_STAFF   AEV_SOUNDCHAN  14 CHAN_WEAPON       sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_VICTORY_STAFF   AEV_SOUNDCHAN  20 CHAN_WEAPON       sound/weapons/saber/saberspin.wav        0 0  0
-	BOTH_VICTORY_STAFF   AEV_SOUNDCHAN  24 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
-	BOTH_VICTORY_STAFF   AEV_SOUNDCHAN  31 CHAN_WEAPON       sound/weapons/saber/saberhitwall1.mp3    0 0  0
-	BOTH_VICTORY_STAFF   AEV_SOUNDCHAN  93 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
-	BOTH_VICTORY_STAFF   AEV_SOUNDCHAN  83 CHAN_AUTO         sound/weapons/force/pull.mp3             0 0  0
-	BOTH_VICTORY_STRONG  AEV_SOUNDCHAN   8 CHAN_WEAPON       sound/weapons/saber/saberhup%d.wav       1 9  0
-	BOTH_VICTORY_STRONG  AEV_SOUNDCHAN  14 CHAN_WEAPON       sound/weapons/saber/saberhitwall1.mp3    0 0  0
-	BOTH_VICTORY_STRONG  AEV_SOUNDCHAN  65 CHAN_AUTO         sound/weapons/force/pull.mp3             0 0  0
-	BOTH_VICTORY_STRONG  AEV_SOUNDCHAN  66 CHAN_AUTO         sound/weapons/saber/saber_catch.mp3      0 0  0
-
-	// mb2 gun melee (bashes)
-	BOTH_DC15_MELEE					AEV_SOUNDCHAN	2	CHAN_AUTO	sound/weapons/tusken_staff/swing%d.wav	1 4  0
-	BOTH_DUAL_PISTOLS_MELEE			AEV_SOUNDCHAN	3	CHAN_AUTO	sound/weapons/tusken_staff/swing%d.wav	1 4  0
-	BOTH_MAND_DUAL_PISTOLS_MELEE	AEV_SOUNDCHAN	3	CHAN_AUTO	sound/weapons/tusken_staff/swing%d.wav	1 4  0
-	BOTH_PISTOL_MELEE			AEV_SOUNDCHAN	3	CHAN_AUTO	sound/weapons/tusken_staff/swing%d.wav	1 4  0
-	BOTH_MAND_PISTOL_MELEE			 AEV_SOUNDCHAN	3	CHAN_AUTO	sound/weapons/tusken_staff/swing%d.wav	1 4  0
-	BOTH_MINIGUN_MELEE		AEV_SOUNDCHAN	4	CHAN_AUTO	sound/weapons/tusken_staff/swing%d.wav	1 4  0
-	BOTH_PLX1_MELEE					AEV_SOUNDCHAN	2	CHAN_AUTO	sound/weapons/tusken_staff/swing%d.wav	1 4  0
-	BOTH_WESTARM5_MELEE	AEV_SOUNDCHAN	1	CHAN_AUTO	sound/weapons/tusken_staff/swing%d.wav	1 4  0
-	
-	// mb2 melee
-	BOTH_A7_KICK_B       AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_BF      AEV_SOUNDCHAN  13 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_BF      AEV_SOUNDCHAN  27 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_B_AIR   AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	        1 4  0
-	BOTH_A7_KICK_F       AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_F_AIR   AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	        1 4  0
-	BOTH_A7_KICK_L       AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_L_AIR   AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	        1 4  0
-	BOTH_A7_KICK_R       AEV_SOUNDCHAN   4 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_RL      AEV_SOUNDCHAN   7 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_R_AIR   AEV_SOUNDCHAN   2 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	        1 4  0
-	BOTH_A7_KICK_S       AEV_SOUNDCHAN   8 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_S       AEV_SOUNDCHAN  13 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_A7_KICK_S       AEV_SOUNDCHAN  18 CHAN_AUTO         sound/weapons/melee/swing%d.mp3         1 4  0
-	BOTH_MELEE_BACKHAND  			 AEV_SOUNDCHAN   7 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_MELEE_UPPERCUT   			AEV_SOUNDCHAN   8 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_MELEE_UPPERCUT   			AEV_SOUNDCHAN   7 	CHAN_AUTO	*combat%d.mp3	                     1 3  50
-	BOTH_THERMAL_MELEE       AEV_SOUNDCHAN   2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			 1 4  0
-
-	// mb2 wookiee
- BOTH_TUSKENLUNGE1        AEV_SOUNDCHAN   4 	CHAN_AUTO	sound/weapons/nda_axe/swing%d.wav 1 3 0
-	BOTH_WOOKIEE_ENRAGE   			AEV_SOUNDCHAN   1 	CHAN_AUTO	*rage1.mp3		                      0 0  0
- BOTH_WOOKIEE_MELEE       AEV_SOUNDCHAN   6 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3		1 4  0
-	BOTH_WOOKIEE_RAGE_MELEE1 AEV_SOUNDCHAN   2 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3		1 4  0
-	BOTH_WOOKIEE_RAGE_MELEE2 AEV_SOUNDCHAN   2 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3		1 4  0
- BOTH_WOOKRAGE            AEV_SOUNDCHAN   6 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3		1 4  0
-
+//Saber special
+BOTH_A1_SPECIAL          AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_A1_SPECIAL          AEV_SOUNDCHAN  8 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_A1_SPECIAL          AEV_SOUNDCHAN 15 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_A1_SPECIAL          AEV_SOUNDCHAN 24 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_A1_SPECIAL          AEV_SOUNDCHAN 34 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_A1_SPECIAL          AEV_SOUNDCHAN 41 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_A1_SPECIAL          AEV_SOUNDCHAN 47 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_A2_SPECIAL          AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_A2_SPECIAL          AEV_SOUNDCHAN 12 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A2_SPECIAL          AEV_SOUNDCHAN 20 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A2_SPECIAL          AEV_SOUNDCHAN 31 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_A2_SPECIAL          AEV_SOUNDCHAN 45 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A2_STABBACK1        AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_A2_STABBACK1        AEV_SOUNDCHAN 12 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A3_SPECIAL          AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_A3_SPECIAL          AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberspin1.wav 0 0 0
+BOTH_A3_SPECIAL          AEV_SOUNDCHAN  8 CHAN_AUTO sound/weapons/saber/saberspin2.wav 0 0 0
+BOTH_A3_SPECIAL          AEV_SOUNDCHAN 13 CHAN_AUTO sound/weapons/saber/saberspin2.wav 0 0 0
+BOTH_A3_SPECIAL          AEV_SOUNDCHAN 18 CHAN_AUTO sound/weapons/saber/saberspin2.wav 0 0 0
+BOTH_A3_SPECIAL          AEV_SOUNDCHAN 25 CHAN_AUTO sound/weapons/saber/saberspin2.wav 0 0 0
+BOTH_A3_SPECIAL          AEV_SOUNDCHAN 28 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A6_SABERPROTECT     AEV_SOUNDCHAN 17 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A6_SABERPROTECT     AEV_SOUNDCHAN 25 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A6_SABERPROTECT     AEV_SOUNDCHAN 31 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A6_SABERPROTECT     AEV_SOUNDCHAN 38 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A6_SABERPROTECT     AEV_SOUNDCHAN 44 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A6_SABERPROTECT     AEV_SOUNDCHAN 50 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A6_SABERPROTECT     AEV_SOUNDCHAN 57 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A6_SABERPROTECT     AEV_SOUNDCHAN 69 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_A7_HILT             AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_A7_KICK_BF          AEV_SOUNDCHAN 13 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_BF          AEV_SOUNDCHAN 27 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_BF_STOP     AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_RL          AEV_SOUNDCHAN  7 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_S           AEV_SOUNDCHAN  8 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_S           AEV_SOUNDCHAN 13 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_S           AEV_SOUNDCHAN 18 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_SOULCAL          AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_A7_SOULCAL          AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A7_SOULCAL          AEV_SOUNDCHAN 17 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A7_SOULCAL          AEV_SOUNDCHAN 33 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_A7_SOULCAL          AEV_SOUNDCHAN 45 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_A7_SOULCAL          AEV_SOUNDCHAN 64 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ARIAL_LEFT          AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_ARIAL_RIGHT         AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_ATTACK_BACK         AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_ATTACK_BACK         AEV_SOUNDCHAN 13 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FL1       AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_BUTTERFLY_FL1       AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FL1       AEV_SOUNDCHAN 11 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FL1       AEV_SOUNDCHAN 18 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FL1       AEV_SOUNDCHAN 30 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FL1       AEV_SOUNDCHAN 36 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FL1       AEV_SOUNDCHAN 49 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FR1       AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_BUTTERFLY_FR1       AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FR1       AEV_SOUNDCHAN 11 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FR1       AEV_SOUNDCHAN 18 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FR1       AEV_SOUNDCHAN 30 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FR1       AEV_SOUNDCHAN 36 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_FR1       AEV_SOUNDCHAN 49 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_LEFT      AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_BUTTERFLY_LEFT      AEV_SOUNDCHAN  9 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_LEFT      AEV_SOUNDCHAN 16 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_LEFT      AEV_SOUNDCHAN 22 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_LEFT      AEV_SOUNDCHAN 29 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_RIGHT     AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_BUTTERFLY_RIGHT     AEV_SOUNDCHAN  9 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_RIGHT     AEV_SOUNDCHAN 16 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_RIGHT     AEV_SOUNDCHAN 22 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_RIGHT     AEV_SOUNDCHAN 29 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_RIGHT     AEV_SOUNDCHAN 35 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_BUTTERFLY_RIGHT     AEV_SOUNDCHAN 45 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_CARTWHEEL_LEFT      AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_CARTWHEEL_RIGHT     AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_CROUCHATTACKBACK1   AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_CROUCHATTACKBACK1   AEV_SOUNDCHAN  8 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_CROUCHATTACKBACK1   AEV_SOUNDCHAN 22 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_CYAN_DFA            AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_CYAN_DFA            AEV_SOUNDCHAN 14 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 7 9 0
+BOTH_FLIP_ATTACK7        AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_FLIP_ATTACK7        AEV_SOUNDCHAN  5 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FLIP_ATTACK7        AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FLIP_ATTACK7        AEV_SOUNDCHAN 15 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FORCELEAP2_T__B_    AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_FORCELEAP2_T__B_    AEV_SOUNDCHAN 22 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FORCELEAP2_T__B_    AEV_SOUNDCHAN 32 CHAN_AUTO *saberhit%d.mp3 1 3 0
+BOTH_FORCELONGLEAP_START AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_JUMPATTACK6         AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_JUMPATTACK6         AEV_SOUNDCHAN  7 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPATTACK6         AEV_SOUNDCHAN 12 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPATTACK6         AEV_SOUNDCHAN 18 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPATTACK6         AEV_SOUNDCHAN 23 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPATTACK6         AEV_SOUNDCHAN 28 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPATTACK6         AEV_SOUNDCHAN 33 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPATTACK7         AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_JUMPATTACK7         AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPATTACK7         AEV_SOUNDCHAN  5 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_JUMPATTACK7         AEV_SOUNDCHAN  9 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPFLIPSLASHDOWN1  AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_JUMPFLIPSLASHDOWN1  AEV_SOUNDCHAN 13 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_JUMPFLIPSTABDOWN    AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_JUMPFLIPSTABDOWN    AEV_SOUNDCHAN 12 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_LUNGE2_B__T_        AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_PALPATINE_DFA       AEV_SOUNDCHAN  1 CHAN_VOICE *combat1.mp3 0 0 0
+BOTH_PALPATINE_DFA       AEV_SOUNDCHAN  2 CHAN_AUTO sound/effects/woosh6.mp3 0 0 0
+BOTH_PALPATINE_DFA       AEV_SOUNDCHAN  5 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_PALPATINE_DFA       AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_PALPATINE_DFA       AEV_SOUNDCHAN 15 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_PALPATINE_DFA       AEV_SOUNDCHAN 20 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_PALPATINE_DFA       AEV_SOUNDCHAN 25 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_PULL_IMPALE_STAB    AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_PULL_IMPALE_STAB    AEV_SOUNDCHAN 22 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_PULL_IMPALE_SWING   AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_PULL_IMPALE_SWING   AEV_SOUNDCHAN 13 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ROLL_STAB           AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_SPINATTACK6         AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_SPINATTACK6         AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK6         AEV_SOUNDCHAN  9 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK6         AEV_SOUNDCHAN 13 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK6         AEV_SOUNDCHAN 16 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK6         AEV_SOUNDCHAN 22 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK6         AEV_SOUNDCHAN 26 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK6         AEV_SOUNDCHAN 29 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK6         AEV_SOUNDCHAN 33 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK7         AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_SPINATTACK7         AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK7         AEV_SOUNDCHAN 16 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK7         AEV_SOUNDCHAN 22 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK7         AEV_SOUNDCHAN 28 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK7         AEV_SOUNDCHAN 32 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SPINATTACK7         AEV_SOUNDCHAN 37 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_STABDOWN            AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_STABDOWN            AEV_SOUNDCHAN  5 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+BOTH_STABDOWN            AEV_SOUNDCHAN 10 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+BOTH_STABDOWN            AEV_SOUNDCHAN 15 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+BOTH_STABDOWN_DUAL       AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_STABDOWN_DUAL       AEV_SOUNDCHAN  5 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+BOTH_STABDOWN_DUAL       AEV_SOUNDCHAN 10 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+BOTH_STABDOWN_DUAL       AEV_SOUNDCHAN 15 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+BOTH_STABDOWN_STAFF      AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_STABDOWN_STAFF      AEV_SOUNDCHAN  5 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+BOTH_STABDOWN_STAFF      AEV_SOUNDCHAN 10 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+BOTH_STABDOWN_STAFF      AEV_SOUNDCHAN 15 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 3 0
+//Saber spin
+BOTH_T6_BL_TL AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BL_TR AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BL_TR AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/saber/saberspin.wav 0 0 0
+BOTH_T6_BL_TR AEV_SOUNDCHAN  7 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BL_TR AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BL_T_ AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BL_T_ AEV_SOUNDCHAN  6 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BL__R AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BL__R AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/saber/saberspin.wav 0 0 0
+BOTH_T6_BL__R AEV_SOUNDCHAN  7 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BL__R AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BR_BL AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BR_TL AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BR_TL AEV_SOUNDCHAN  6 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BR__L AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_BR__L AEV_SOUNDCHAN  6 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_TL_BR AEV_SOUNDCHAN  8 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_TL__R AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_TL__R AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/saber/saberspin.wav 0 0 0
+BOTH_T6_TL__R AEV_SOUNDCHAN  7 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_TL__R AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_TR_BL AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_TR_TL AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_TR_T_ AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberspin.wav 0 0 0
+BOTH_T6_TR__L AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_T__BR AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_T__TL AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_T___L AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6_T___R AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__L_BR AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__L_BR AEV_SOUNDCHAN  6 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__L_T_ AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__L_T_ AEV_SOUNDCHAN  8 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__L__R AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__L__R AEV_SOUNDCHAN  7 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__R_BL AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__R_BR AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__R_TL AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__R_TL AEV_SOUNDCHAN  6 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__R_TL AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__R_T_ AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T6__R__L AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_BL_BR AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_BL_TR AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_BL__R AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_BR_T_ AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_BR_T_ AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_BR__L AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_TL_BR AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_TL_BR AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_TL_TR AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_TL__R AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_TR_BL AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_TR_TL AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_TR__L AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_T__BR AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7_T__TR AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7__L_TR AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7__R_TL AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7__R_T_ AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_T7__R__L AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_V6_TR_S6 AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_V6_T__S6 AEV_SOUNDCHAN  3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+//Gesture
+BOTH_ALORA_SPIN       AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_ALORA_SPIN_SLASH AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/force/360pushwindup.wav 0 0 0
+BOTH_ALORA_SPIN_SLASH AEV_SOUNDCHAN 17 CHAN_AUTO sound/weapons/saber/saberhup%d.mp3 1 9 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/force/jump.mp3 0 0 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN  6 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN 46 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN 71 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN 74 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN 78 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN 80 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN 84 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_ALORA_TAUNT      AEV_SOUNDCHAN 95 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_BOW              AEV_SOUNDCHAN 12 CHAN_AUTO sound/player/footsteps/bare%d.mp3 1 9 0
+BOTH_COLLAPSED_GETUP  AEV_SOUNDCHAN  2 CHAN_BODY sound/effects/cloth2.mp3 0 0 0
+BOTH_COME_ON1         AEV_SOUNDCHAN 17 CHAN_AUTO s/w/v/swish1.wav 0 0 0
+BOTH_COWER1           AEV_SOUNDCHAN  1 CHAN_AUTO s/w/v/swish1.wav 0 0 0
+BOTH_DATAPAD_USE      AEV_SOUNDCHAN  4 CHAN_BODY sound/interface/menuroam.mp3 0 0 0
+BOTH_DATAPAD_USE      AEV_SOUNDCHAN  9 CHAN_BODY sound/interface/esc.mp3 0 0 0
+BOTH_DOOKU_TAUNT      AEV_SOUNDCHAN  2 CHAN_WEAPON sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_DOOKU_TAUNT      AEV_SOUNDCHAN 16 CHAN_WEAPON sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_DOOKU_TAUNT      AEV_SOUNDCHAN 27 CHAN_WEAPON sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_DUAL_TAUNT       AEV_SOUNDCHAN 11 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_DUAL_TAUNT       AEV_SOUNDCHAN 73 CHAN_WEAPON sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_ENGAGETAUNT      AEV_SOUNDCHAN  1 CHAN_AUTO s/w/v/swish1.wav 0 0 0
+BOTH_FAINT            AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/force/drain.mp3 0 0 0
+BOTH_FAINT            AEV_SOUNDCHAN 20 CHAN_AUTO sound/effects/cloth3.mp3 0 0 0
+BOTH_FAINT            AEV_SOUNDCHAN 40 CHAN_AUTO sound/interface/choose_torso.mp3 0 0 0
+BOTH_FISTBUMP         AEV_SOUNDCHAN  1 CHAN_AUTO sound/effects/cloth3.mp3 0 0 0
+BOTH_FISTBUMP         AEV_SOUNDCHAN  9 CHAN_AUTO s/w/v/swish1.wav 0 0 0
+BOTH_FJSS_TL_BR       AEV_SOUNDCHAN 16 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FJSS_TL_BR       AEV_SOUNDCHAN 27 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FJSS_TL_BR       AEV_SOUNDCHAN 54 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FJSS_TR_BL       AEV_SOUNDCHAN 16 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FJSS_TR_BL       AEV_SOUNDCHAN 27 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_FJSS_TR_BL       AEV_SOUNDCHAN 54 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 20 CHAN_WEAPON sound/weapons/force/pull.mp3 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 33 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 41 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 48 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 52 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 56 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 59 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 62 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 66 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 70 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 77 CHAN_WEAPON sound/weapons/saber/saberspinoff.wav 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 88 CHAN_WEAPON sound/weapons/force/pull.mp3 0 0 0
+BOTH_GESTURE1         AEV_SOUNDCHAN 97 CHAN_WEAPON sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_GUNGAN_TAUNT     AEV_SOUNDCHAN  1 CHAN_VOICE *bns_frustration1.mp3  0 0 0
+BOTH_HANDSUP                AEV_SOUNDCHAN   1 CHAN_AUTO sound/effects/cloth3.mp3 0 0 0
+BOTH_HAN_TAUNT              AEV_SOUNDCHAN   2 CHAN_AUTO sound/interface/choose_torso.mp3 0 0 0
+BOTH_HUGGEE1                AEV_SOUNDCHAN  16 CHAN_AUTO sound/chars/spongebob/misc/jump1.wav 0 0 0
+BOTH_HUGGER1                AEV_SOUNDCHAN  16 CHAN_AUTO sound/effects/cloth3.mp3 0 0 0
+BOTH_INJURED_TO_COLLAPSED   AEV_SOUNDCHAN   5 CHAN_BODY sound/player/footsteps/bare%d.mp3 1 4 0
+BOTH_INJURED_TO_COLLAPSED   AEV_SOUNDCHAN  14 CHAN_BODY sound/player/footsteps/bare%d.mp3 1 4 0
+BOTH_JANGO_TAUNT            AEV_SOUNDCHAN   2 CHAN_WEAPON sound/weapons/bryar/select.mp3 0 0 0
+BOTH_JANGO_TAUNT            AEV_SOUNDCHAN   9 CHAN_WEAPON sound/weapons/tai_weap/swing3.wav 0 0 0
+BOTH_JANGO_TAUNT            AEV_SOUNDCHAN  13 CHAN_WEAPON sound/weapons/tai_weap/swing3.wav 0 0 0
+BOTH_JANGO_TAUNT            AEV_SOUNDCHAN  17 CHAN_WEAPON sound/weapons/tai_weap/swing3.wav 0 0 0
+BOTH_MAUL_TAUNT             AEV_SOUNDCHAN   1 CHAN_AUTO sound/effects/cloth3.mp3 0 0 0
+BOTH_MAUL_TAUNT             AEV_SOUNDCHAN   3 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_MAUL_TAUNT             AEV_SOUNDCHAN  11 CHAN_AUTO s/w/v/swish1.wav 0 0 0
+BOTH_RIGHTHANDCHOPPEDOFF    AEV_SOUNDCHAN  25 CHAN_VOICE *death%d.wav 1 3 30
+BOTH_RIGHTHANDCHOPPEDOFF    AEV_SOUNDCHAN  64 CHAN_VOICE *death%d.wav 1 3 0
+BOTH_RIGHTHANDCHOPPEDOFF    AEV_SOUNDCHAN  88 CHAN_VOICE *death%d.wav 1 3 30
+BOTH_RIGHTHANDCHOPPEDOFF    AEV_SOUNDCHAN 100 CHAN_VOICE *death%d.wav 1 3 30
+BOTH_RIGHTHANDCHOPPEDOFF    AEV_SOUNDCHAN 110 CHAN_AUTO sound/player/roll1.wav 0 0 0
+BOTH_ROSH_HEAL              AEV_SOUNDCHAN  11 CHAN_AUTO sound/interface/choose_torso.mp3 0 0 0
+BOTH_SABERKILLER1           AEV_SOUNDCHAN   1 CHAN_AUTO sound/effects/cloth2.mp3 0 0 0
+BOTH_SABERKILLER1           AEV_SOUNDCHAN  12 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_SABERTHROW1START       AEV_SOUNDCHAN  27 CHAN_WEAPON sound/weapons/saberot/saberspin.wav 0 0 0
+BOTH_SABERTHROW1START       AEV_SOUNDCHAN  42 CHAN_WEAPON sound/weapons/saberot/saberspin.wav 0 0 0
+BOTH_SABERTHROW1START       AEV_SOUNDCHAN  53 CHAN_WEAPON sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_SALUTE                 AEV_SOUNDCHAN   1 CHAN_AUTO sound/interface/choose_torso.mp3 0 0 0
+BOTH_SALUTE                 AEV_SOUNDCHAN   9 CHAN_AUTO s/w/v/swish1.wav 0 0 0
+BOTH_SHOWOFF_DUAL           AEV_EFFECT      4 saber/saber_block *blade1 0
+BOTH_SHOWOFF_DUAL           AEV_SOUNDCHAN   6 CHAN_AUTO sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_SHOWOFF_DUAL           AEV_SOUNDCHAN   6 CHAN_AUTO sound/weapons/saber/saberblock2.mp3 0 0 0
+BOTH_SHOWOFF_DUAL           AEV_SOUNDCHAN   8 CHAN_AUTO sound/weapons/saber/saberblock5.mp3 0 0 0
+BOTH_SHOWOFF_DUAL           AEV_SOUNDCHAN  10 CHAN_AUTO sound/weapons/saber/saberblock2.mp3 0 0 0
+BOTH_SHOWOFF_DUAL           AEV_SOUNDCHAN  12 CHAN_AUTO sound/weapons/saber/saberblock4.mp3 0 0 0
+BOTH_SHOWOFF_DUAL           AEV_SOUNDCHAN  13 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_SHOWOFF_FAST           AEV_SOUNDCHAN   3 CHAN_AUTO sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_SHOWOFF_MEDIUM         AEV_SOUNDCHAN   1 CHAN_AUTO sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_SHOWOFF_MEDIUM         AEV_SOUNDCHAN  15 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_SHOWOFF_STAFF          AEV_SOUNDCHAN   5 CHAN_AUTO sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_SHOWOFF_STAFF          AEV_SOUNDCHAN  26 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_SHOWOFF_STRONG         AEV_SOUNDCHAN   1 CHAN_AUTO sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_SHOWOFF_STRONG         AEV_SOUNDCHAN  15 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_STAND5STARTLEDLOOKLEFT AEV_SOUNDCHAN   1 CHAN_BODY sound/interface/choose_torso.mp3 0 0 0
+BOTH_STAND5TOAIM            AEV_SOUNDCHAN   9 CHAN_BODY sound/weapons/bowcaster/select.mp3 0 0 0
+BOTH_TAVION_SCEPTERGROUND   AEV_SOUNDCHAN  14 CHAN_WEAPON sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_TAVION_SCEPTERGROUND   AEV_SOUNDCHAN  25 CHAN_WEAPON sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_TAVION_SCEPTERGROUND   AEV_SOUNDCHAN  28 CHAN_WEAPON sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_TAVION_SCEPTERGROUND   AEV_SOUNDCHAN  40 CHAN_WEAPON sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_TAVION_SCEPTERGROUND   AEV_SOUNDCHAN  50 CHAN_WEAPON sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_TAVION_SWORDPOWER      AEV_SOUNDCHAN   7 CHAN_WEAPON sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_TAVION_SWORDPOWER      AEV_SOUNDCHAN  40 CHAN_WEAPON sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_TAVION_SWORDPOWER      AEV_SOUNDCHAN  74 CHAN_WEAPON sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_THUMBSUP               AEV_SOUNDCHAN   1 CHAN_AUTO sound/interface/choose_torso.mp3 0 0 0
+BOTH_THUMBSUP               AEV_SOUNDCHAN   9 CHAN_AUTO s/w/v/swish1.wav 0 0 0
+BOTH_TOSS1                  AEV_SOUNDCHAN   8 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_TOSS2                  AEV_SOUNDCHAN  17 CHAN_WEAPON sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_TUSKENATTACK1          AEV_SOUNDCHAN   6 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_TUSKENATTACK2          AEV_SOUNDCHAN   6 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_TUSKENATTACK3          AEV_SOUNDCHAN   4 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_VADER_TAUNT            AEV_SOUNDCHAN   1 CHAN_AUTO s/w/v/swish1.wav 0 0 0
+BOTH_VADER_TAUNT            AEV_SOUNDCHAN   5 CHAN_AUTO sound/weapons/force/grip.mp3 0 0 0
+BOTH_VADER_TAUNT            AEV_SOUNDCHAN  23 CHAN_AUTO sound/weapons/force/drained.mp3 0 0 0
+BOTH_VICTORY_DUAL           AEV_SOUNDCHAN   6 CHAN_WEAPON sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_VICTORY_DUAL           AEV_SOUNDCHAN  15 CHAN_AUTO sound/weapons/saber/saberblock3.mp3 0 0 0
+BOTH_VICTORY_DUAL           AEV_EFFECT     15 saber/saber_block *blade1
+BOTH_VICTORY_FAST           AEV_SOUNDCHAN  10 CHAN_AUTO sound/effects/cloth2.mp3 0 0 0
+BOTH_VICTORY_FAST           AEV_SOUNDCHAN  15 CHAN_WEAPON sound/weapons/saber/saberhup%d.mp3 1 3 0
+BOTH_VICTORY_MEDIUM         AEV_SOUNDCHAN   7 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_VICTORY_MEDIUM         AEV_SOUNDCHAN  25 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_VICTORY_STAFF          AEV_SOUNDCHAN  13 CHAN_AUTO sound/weapons/saber/saberspin%d.wav 1 3 0
+BOTH_VICTORY_STAFF          AEV_SOUNDCHAN  24 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_VICTORY_STAFF          AEV_SOUNDCHAN  83 CHAN_AUTO sound/weapons/force/pull.mp3 0 0 0
+BOTH_VICTORY_STAFF          AEV_SOUNDCHAN  93 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+BOTH_VICTORY_STRONG         AEV_SOUNDCHAN   8 CHAN_WEAPON sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_VICTORY_STRONG         AEV_SOUNDCHAN  62 CHAN_AUTO sound/weapons/force/pull.mp3 0 0 0
+BOTH_VICTORY_STRONG         AEV_SOUNDCHAN  66 CHAN_AUTO sound/weapons/saber/saber_catch.mp3 0 0 0
+TORSO_SURRENDER_START AEV_SOUNDCHAN  1 CHAN_AUTO  sound/interface/choose_torso.mp3   0 0 0
+//Movement
+BOTH_BACK_FLIP_UP             AEV_SOUNDCHAN 10 CHAN_AUTO sound/weapons/force/jump.mp3 0 0 0
+BOTH_DODGE_BL                 AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DODGE_BR                 AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DODGE_FL                 AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DODGE_FR                 AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DODGE_L                  AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DODGE_R                  AEV_SOUNDCHAN  4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FORCEWALLREBOUND_BACK    AEV_SOUNDCHAN  1 CHAN_AUTO sound/player/land1.wav 0 0 0
+BOTH_FORCEWALLREBOUND_FORWARD AEV_SOUNDCHAN  1 CHAN_AUTO sound/player/land1.wav 0 0 0
+BOTH_FORCEWALLREBOUND_LEFT    AEV_SOUNDCHAN  1 CHAN_AUTO sound/player/land1.wav 0 0 0
+BOTH_FORCEWALLREBOUND_RIGHT   AEV_SOUNDCHAN  1 CHAN_AUTO sound/player/land1.wav 0 0 0
+BOTH_FORCEWALLRUNFLIP_ALT     AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FORCEWALLRUNFLIP_ALT     AEV_SOUNDCHAN  2 CHAN_AUTO sound/player/land1.wav 0 0 0
+BOTH_FORCEWALLRUNFLIP_END     AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FORCEWALLRUNFLIP_END     AEV_SOUNDCHAN  2 CHAN_AUTO sound/player/land1.wav 0 0 0
+BOTH_LEG_STIM                 AEV_EFFECT     2 force/heal
+BOTH_ROLL_B                   AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_ROLL_F                   AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_ROLL_L                   AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_ROLL_R                   AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WALL_RUN_LEFT_STOP       AEV_SOUNDCHAN  1 CHAN_AUTO sound/player/land1.wav 0 0 0
+BOTH_WALL_RUN_RIGHT_STOP      AEV_SOUNDCHAN  1 CHAN_AUTO sound/player/land1.wav 0 0 0
+//Force Power
+BOTH_360PUSH       AEV_SOUNDCHAN  8 CHAN_VOICE *combat%d.mp3 1 3 50
+BOTH_FORCEDARKRAGE AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/force/rage.mp3 1 3 0
+BOTH_FORCEDARKRAGE AEV_EFFECT     1 force/rage2
+BOTH_FORCEDARKRAGE AEV_SOUNDCHAN  2 CHAN_VOICE *taunt%d.mp3 1 3 0
+BOTH_FORCEDARKRAGE AEV_SOUNDCHAN 12 CHAN_AUTO *woosh6.mp3 1 3 0
+//Wook
+BOTH_TUSKENLUNGE1        AEV_SOUNDCHAN 4 CHAN_AUTO sound/weapons/nda_axe/swing%d.wav 1 3 0
+BOTH_WOOKIEE_ENRAGE      AEV_SOUNDCHAN 1 CHAN_AUTO *rage1.mp3 0 0 0
+BOTH_WOOKIEE_MELEE       AEV_SOUNDCHAN 6 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WOOKIEE_RAGE_MELEE1 AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WOOKIEE_RAGE_MELEE2 AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WOOKRAGE            AEV_SOUNDCHAN 6 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+//Gunbash
+BOTH_AMBAN_MELEE             AEV_SOUNDCHAN 1 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_DC15_MELEE              AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_DUAL_PISTOLS_MELEE      AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_MAND_DUAL_PISTOLS_MELEE AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_MAND_PISTOL_MELEE       AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_MELEE1_BLASTER          AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MELEE_BACKHAND          AEV_SOUNDCHAN 5 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MINIGUN_MELEE           AEV_SOUNDCHAN 3 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_MINIGUN_MELEE_KICK      AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_PISTOL_MELEE            AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_PLX1_MELEE              AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+BOTH_THERMAL_MELEE           AEV_SOUNDCHAN 2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WESTARM5_MELEE          AEV_SOUNDCHAN 1 CHAN_AUTO sound/weapons/tusken_staff/swing%d.wav 1 4 0
+//Melee
+BOTH_A7_KICK_B      AEV_SOUNDCHAN   4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_B_AIR  AEV_SOUNDCHAN   2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_F      AEV_SOUNDCHAN   4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_F_AIR  AEV_SOUNDCHAN   2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_L      AEV_SOUNDCHAN   4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_L_AIR  AEV_SOUNDCHAN   2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_R      AEV_SOUNDCHAN   4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_KICK_R_AIR  AEV_SOUNDCHAN   2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_KYLE_GRAB      AEV_SOUNDCHAN   1 CHAN_AUTO sound/effects/cloth1.mp3 0 0 0
+BOTH_KYLE_GRAB      AEV_SOUNDCHAN   9 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN   1 CHAN_AUTO sound/effects/grab_cloth1.mp3 0 0 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN   2 CHAN_AUTO *jump1.mp3 0 0 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN  23 CHAN_AUTO *taunt%d.mp3 1 5 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN  24 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN  25 CHAN_AUTO sound/weapons/melee/punch%d.mp3 1 4 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN  46 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN  49 CHAN_AUTO sound/weapons/melee/punch%d.mp3 1 4 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN  80 CHAN_AUTO *victory%d.mp3 1 3 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN  81 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_KYLE_PA_1      AEV_SOUNDCHAN  85 CHAN_AUTO sound/weapons/melee/kick%d.mp3 1 4 0
+BOTH_KYLE_PA_2      AEV_SOUNDCHAN   1 CHAN_AUTO sound/effects/grab_cloth1.mp3 0 0 0
+BOTH_KYLE_PA_2      AEV_SOUNDCHAN   2 CHAN_AUTO *jump1.mp3 0 0 0
+BOTH_KYLE_PA_2      AEV_SOUNDCHAN   8 CHAN_AUTO *taunt%d.mp3 1 5 0
+BOTH_KYLE_PA_2      AEV_SOUNDCHAN  32 CHAN_WEAPON sound/weapons/melee/kick%d.mp3 1 4 0
+BOTH_KYLE_PA_2      AEV_SOUNDCHAN  49 CHAN_AUTO sound/weapons/force/pull.mp3 0 0 0
+BOTH_KYLE_PA_2      AEV_SOUNDCHAN  63 CHAN_AUTO *gloat%d.mp3 1 3 0
+BOTH_KYLE_PA_2      AEV_SOUNDCHAN  85 CHAN_AUTO sound/weapons/force/push.mp3 0 0 0
+BOTH_KYLE_PA_3      AEV_SOUNDCHAN   1 CHAN_WEAPON sound/effects/grab_cloth1.mp3 0 0 0
+BOTH_KYLE_PA_3      AEV_SOUNDCHAN   2 CHAN_VOICE *jump1.mp3 0 0 0
+BOTH_KYLE_PA_3      AEV_SOUNDCHAN  16 CHAN_WEAPON sound/movers/objects/objecthit.wav 0 0 0
+BOTH_KYLE_PA_3      AEV_SOUNDCHAN  24 CHAN_AUTO *taunt%d.mp3 1 5 0
+BOTH_KYLE_PA_3      AEV_SOUNDCHAN  48 CHAN_WEAPON sound/effects/grab_cloth5.mp3 0 0 0
+BOTH_KYLE_PA_3      AEV_SOUNDCHAN  75 CHAN_WEAPON sound/effects/cloth1.mp3 0 0 0
+BOTH_KYLE_PA_3      AEV_SOUNDCHAN 117 CHAN_AUTO *gloat%d.mp3 1 3 0
+BOTH_KYLE_PA_3      AEV_SOUNDCHAN 143 CHAN_AUTO sound/weapons/force/push.mp3 0 0 0
+BOTH_MELEE1         AEV_SOUNDCHAN   2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MELEE2         AEV_SOUNDCHAN   2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MELEE6         AEV_SOUNDCHAN   2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MELEE_BLOCK_C  AEV_SOUNDCHAN   1 CHAN_BODY sound/weapons/melee/swing2.mp3 1 4 0
+BOTH_MELEE_UPPERCUT AEV_SOUNDCHAN   2 CHAN_AUTO *jump1.mp3 0 0 0
+BOTH_MELEE_UPPERCUT AEV_SOUNDCHAN   7 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_PLAYER_PA_1    AEV_SOUNDCHAN   1 CHAN_AUTO *land1.mp3 0 0 0
+BOTH_PLAYER_PA_2    AEV_SOUNDCHAN   2 CHAN_AUTO *land1.mp3 0 0 0
+BOTH_PLAYER_PA_2    AEV_SOUNDCHAN  35 CHAN_AUTO *gasp.mp3 0 0 0
+BOTH_PLAYER_PA_2    AEV_SOUNDCHAN  47 CHAN_AUTO *pain50.mp3 0 0 0
+BOTH_PLAYER_PA_3    AEV_SOUNDCHAN   1 CHAN_AUTO *pushed%d.mp3 1 3 0
+BOTH_PLAYER_PA_3    AEV_SOUNDCHAN  20 CHAN_AUTO *land1.mp3 0 0 0
+BOTH_PLAYER_PA_3    AEV_SOUNDCHAN  54 CHAN_AUTO *choke%d.mp3 1 3 0
+BOTH_PLAYER_PA_3    AEV_SOUNDCHAN  73 CHAN_AUTO *pushed%d.mp3 1 3 0
+BOTH_PLAYER_PA_3    AEV_SOUNDCHAN 141 CHAN_VOICE *pushed%d.mp3 1 3 0
+BOTH_THROW          AEV_SOUNDCHAN   1 CHAN_AUTO sound/effects/grab_cloth1.mp3 0 0 0
+BOTH_THROW          AEV_SOUNDCHAN   2 CHAN_AUTO *taunt%d.mp3 1 3 0
+BOTH_THROW          AEV_SOUNDCHAN   4 CHAN_WEAPON sound/movers/objects/objecthit.wav 0 0 0
+BOTH_THROW          AEV_SOUNDCHAN   6 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_THROW1         AEV_SOUNDCHAN   1 CHAN_WEAPON sound/movers/objects/objecthit.wav 0 0 0
+BOTH_THROW1         AEV_SOUNDCHAN   2 CHAN_AUTO *taunt%d.mp3 1 3 0
+BOTH_THROW1         AEV_SOUNDCHAN   3 CHAN_AUTO sound/effects/grab_cloth1.mp3 0 0 0
+BOTH_THROW1         AEV_SOUNDCHAN  22 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_THROW1         AEV_SOUNDCHAN  25 CHAN_AUTO sound/weapons/melee/punch%d.mp3 1 4 0
+BOTH_THROW2         AEV_SOUNDCHAN   1 CHAN_WEAPON sound/movers/objects/objecthit.wav 0 0 0
+BOTH_THROW2         AEV_SOUNDCHAN   2 CHAN_AUTO *taunt%d.mp3 1 3 0
+BOTH_THROW2         AEV_SOUNDCHAN   3 CHAN_AUTO sound/effects/grab_cloth1.mp3 0 0 0
+BOTH_THROW2         AEV_SOUNDCHAN  19 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_THROW2         AEV_SOUNDCHAN  22 CHAN_AUTO sound/weapons/melee/punch%d.mp3 1 4 0
+//Swim
+BOTH_MELEE_SWIMBACK    AEV_SOUNDCHAN 10 CHAN_AUTO sound/player/footsteps/water_wade_0%d.mp3 1 4 0
+BOTH_MELEE_SWIMFORWARD AEV_SOUNDCHAN  1 CHAN_AUTO sound/player/footsteps/water_wade_0%d.mp3 1 4 0
+BOTH_SWIMFORWARD       AEV_SOUNDCHAN  1 CHAN_AUTO sound/player/footsteps/water_wade_02.mp3 1 4 0
+TORSO_MELEE1_SWIMFORWARD         AEV_SOUNDCHAN  3 CHAN_AUTO sound/player/footsteps/water_wade_0%d.mp3 1 4 0
+TORSO_MELEE2_SWIMFORWARD         AEV_SOUNDCHAN  3 CHAN_AUTO sound/player/footsteps/water_wade_0%d.mp3 1 4 0
+TORSO_MELEE_BACKHAND_SWIMFORWARD AEV_SOUNDCHAN  5 CHAN_AUTO sound/player/footsteps/water_wade_0%d.mp3 1 4 0
+TORSO_MELEE_BLOCK_SWIMFORWARD    AEV_SOUNDCHAN  4 CHAN_AUTO sound/player/footsteps/water_wade_0%d.mp3 1 4 0
+TORSO_WOOKIEE_MELEE_SWIMFORWARD  AEV_SOUNDCHAN  4 CHAN_AUTO sound/player/footsteps/water_wade_0%d.mp3 1 4 0
+TORSO_WRISTSHOT_SWIMFORWARD      AEV_SOUNDCHAN  4 CHAN_AUTO sound/player/footsteps/water_wade_0%d.mp3 1 4 0
+//Vehicle
+BOTH_VS_DISMOUNT_L AEV_SOUNDCHAN  6 CHAN_BODY sound/interface/choose_torso.mp3 0 0 0
+BOTH_VS_DISMOUNT_R AEV_SOUNDCHAN  6 CHAN_BODY sound/interface/choose_torso.mp3 0 0 0
+BOTH_VS_MOUNT_L    AEV_SOUNDCHAN 10 CHAN_BODY sound/interface/choose_torso.mp3 0 0 0
+BOTH_VS_MOUNT_L    AEV_SOUNDCHAN 17 CHAN_BODY sound/effects/cloth3.mp3 0 0 0
+BOTH_VS_MOUNT_R    AEV_SOUNDCHAN 10 CHAN_BODY sound/interface/choose_torso.mp3 0 0 0
+BOTH_VS_MOUNT_R    AEV_SOUNDCHAN 17 CHAN_BODY sound/effects/cloth3.mp3 0 0 0
+BOTH_VS_TURBO      AEV_EFFECT     1 emitter/smoke_trail
+BOTH_VS_TURBO      AEV_SOUNDCHAN  9 CHAN_AUTO sound/effects/woosh2.mp3 0 0 0
+BOTH_VT_MOUNT_B    AEV_SOUNDCHAN  3 CHAN_BODY sound/interface/choose_torso.mp3 0 0 0
+BOTH_VT_MOUNT_B    AEV_SOUNDCHAN 13 CHAN_BODY sound/effects/cloth3.mp3 0 0 0
+BOTH_VT_MOUNT_L    AEV_SOUNDCHAN 10 CHAN_BODY sound/interface/choose_torso.mp3 0 0 0
+BOTH_VT_MOUNT_L    AEV_SOUNDCHAN 28 CHAN_BODY sound/effects/cloth3.mp3 0 0 0
+BOTH_VT_MOUNT_R    AEV_SOUNDCHAN 10 CHAN_BODY sound/interface/choose_torso.mp3 0 0 0
+BOTH_VT_MOUNT_R    AEV_SOUNDCHAN 28 CHAN_BODY sound/effects/cloth3.mp3 0 0 0
+BOTH_VT_TURBO      AEV_EFFECT     1 emitter/smoke_trail
+BOTH_VT_TURBO      AEV_SOUNDCHAN  1 CHAN_AUTO sound/effects/woosh2.mp3 0 0 0
 }
-
 LOWEREVENTS
 {
-	BOTH_A1_SPECIAL      AEV_FOOTSTEP    7 footstep_l        0
-	BOTH_A2_SPECIAL      AEV_FOOTSTEP    7 footstep_r        0
-	BOTH_A2_SPECIAL      AEV_FOOTSTEP   15 footstep_l        0
-	BOTH_A2_SPECIAL      AEV_FOOTSTEP   42 footstep_r        0
-	BOTH_A2_SPECIAL      AEV_FOOTSTEP   47 footstep_l        0
-	BOTH_A2_STABBACK1	   AEV_FOOTSTEP 	12 footstep_r         0
-	BOTH_A2_STABBACK1	   AEV_FOOTSTEP 	39 footstep_r         0
-	BOTH_A3_SPECIAL      AEV_FOOTSTEP    8 footstep_l        0
-	BOTH_A3_SPECIAL      AEV_FOOTSTEP   21 footstep_r        0
-	BOTH_A3_SPECIAL      AEV_FOOTSTEP   30 footstep_l        0
-	BOTH_A7_HILT		       AEV_SOUNDCHAN	11 CHAN_AUTO		        sound/weapons/melee/swing%d.mp3    1 4  0
-	BOTH_A7_SOULCAL      AEV_FOOTSTEP   11 footstep_l        0
-	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  16 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav 1 9  0
-	BOTH_A7_SOULCAL      AEV_FOOTSTEP   20 footstep_r        0
-	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  27 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	   1 4  0
-	BOTH_A7_SOULCAL      AEV_FOOTSTEP   32 footstep_l        0
-	BOTH_A7_SOULCAL      AEV_FOOTSTEP   33 footstep_r        0
-	BOTH_A7_SOULCAL      AEV_FOOTSTEP   39 footstep_l        0
-	BOTH_A7_SOULCAL      AEV_FOOTSTEP   45 footstep_r        0
-	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  58 CHAN_AUTO         sound/player/roll1.wav            0 0  0
-	BOTH_ARIAL_LEFT	   	 AEV_FOOTSTEP 	 4 footstep_l        0
-	BOTH_ARIAL_LEFT	     AEV_FOOTSTEP 	18 footstep_r        0
-	BOTH_ARIAL_LEFT	     AEV_FOOTSTEP 	21 footstep_l        0
-	BOTH_ARIAL_RIGHT	    AEV_FOOTSTEP 	 4 footstep_r        0
-	BOTH_ARIAL_RIGHT	    AEV_FOOTSTEP 	18 footstep_l        0
-	BOTH_ARIAL_RIGHT	    AEV_FOOTSTEP 	21 footstep_r        0
-	BOTH_ATTACK_BACK	    AEV_FOOTSTEP 	13 footstep_r        0
-	BOTH_ATTACK_BACK	    AEV_FOOTSTEP 	27 footstep_r        0
-	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	 6 footstep_r        0
-	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	13 footstep_l        0
-	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	31 footstep_r        0
-	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	37 footstep_l        0
-	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	45 footstep_r        0
-	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	52 footstep_l        0
-	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	 6 footstep_l        0
-	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	13 footstep_r        0
-	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	32 footstep_l        0
-	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	36 footstep_r        0
-	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	45 footstep_l        0
-	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	52 footstep_r        0
-	BOTH_BUTTERFLY_LEFT  AEV_FOOTSTEP 	11 footstep_l        0
-	BOTH_BUTTERFLY_LEFT  AEV_FOOTSTEP 	29 footstep_l        0
-	BOTH_BUTTERFLY_LEFT  AEV_FOOTSTEP 	35 footstep_r        0
-	BOTH_BUTTERFLY_LEFT  AEV_FOOTSTEP 	44 footstep_l        0
-	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	 6 footstep_l        0
-	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	13 footstep_r        0
-	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	32 footstep_l        0
-	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	36 footstep_r        0
-	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	44 footstep_l        0
-	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	52 footstep_r        0
-	BOTH_CARTWHEEL_LEFT  AEV_FOOTSTEP 	 2 footstep_l        0
-	BOTH_CARTWHEEL_LEFT  AEV_FOOTSTEP 	15 footstep_r        0
-	BOTH_CARTWHEEL_LEFT  AEV_FOOTSTEP 	16 footstep_l        0
-	BOTH_CARTWHEEL_RIGHT AEV_FOOTSTEP 	 2 footstep_r        0
-	BOTH_CARTWHEEL_RIGHT AEV_FOOTSTEP 	15 footstep_l        0
-	BOTH_CARTWHEEL_RIGHT AEV_FOOTSTEP 	16 footstep_r        0
-	BOTH_DEATH1          AEV_SOUNDCHAN  13 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH10         AEV_SOUNDCHAN  26 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH10         AEV_SOUNDCHAN  52 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH11         AEV_SOUNDCHAN  19 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH11         AEV_SOUNDCHAN  40 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH12         AEV_SOUNDCHAN  14 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH13         AEV_SOUNDCHAN  33 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH14         AEV_SOUNDCHAN  24 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH15         AEV_SOUNDCHAN  15 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH15         AEV_SOUNDCHAN  43 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH16         AEV_SOUNDCHAN  14 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH17         AEV_SOUNDCHAN  56 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH18         AEV_SOUNDCHAN  68 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH19         AEV_SOUNDCHAN  68 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH2          AEV_SOUNDCHAN  13 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH20         AEV_SOUNDCHAN  33 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH21         AEV_SOUNDCHAN  34 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH22         AEV_SOUNDCHAN   6 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH23         AEV_SOUNDCHAN   6 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH24         AEV_SOUNDCHAN  15 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH25         AEV_SOUNDCHAN  15 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH3          AEV_SOUNDCHAN  15 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH4          AEV_SOUNDCHAN  19 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH5          AEV_SOUNDCHAN  19 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH6          AEV_SOUNDCHAN  14 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH7          AEV_SOUNDCHAN  13 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH8          AEV_SOUNDCHAN  17 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH9          AEV_SOUNDCHAN  21 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_DEATH9          AEV_SOUNDCHAN  40 CHAN_AUTO         sound/player/bodyfall_human%d.wav        1 3  0
-	BOTH_FORCELAND1	     AEV_FOOTSTEP 	 2 footstep_l        0
-	BOTH_FORCELAND1	     AEV_FOOTSTEP 	 3 footstep_r        0
-	BOTH_FORCELANDBACK1  AEV_FOOTSTEP 	 1 footstep_l        0
-	BOTH_FORCELANDBACK1  AEV_FOOTSTEP 	 4 footstep_r        0
-	BOTH_FORCELANDLEFT1  AEV_FOOTSTEP 	 2 footstep_r        0
-	BOTH_FORCELANDLEFT1  AEV_FOOTSTEP  	 3 footstep_l        0
-	BOTH_FORCELANDRIGHT1 AEV_FOOTSTEP  	 2 footstep_l        0
-	BOTH_FORCELANDRIGHT1 AEV_FOOTSTEP  	 3 footstep_r        0
-	BOTH_FORCELEAP2_T__B_ AEV_FOOTSTEP  27 footstep_r        0
-	BOTH_FORCELEAP2_T__B_ AEV_FOOTSTEP  28 footstep_l        0
-	BOTH_FORCEWALLREBOUND_BACK AEV_SOUNDCHAN 1 CHAN_AUTO     sound/player/land1.wav                  0 0  0
-	BOTH_FORCEWALLREBOUND_BACK AEV_SOUNDCHAN  2 CHAN_AUTO    sound/weapons/melee/swing%d.mp3	        1 4  0
-	BOTH_FORCEWALLREBOUND_FORWARD AEV_SOUNDCHAN 1 CHAN_AUTO  sound/player/land1.wav                  0 0  0
-	BOTH_FORCEWALLREBOUND_FORWARD AEV_SOUNDCHAN  2 CHAN_AUTO    sound/weapons/melee/swing%d.mp3	     1 4  0
-	BOTH_FORCEWALLREBOUND_LEFT AEV_SOUNDCHAN 1 CHAN_AUTO     sound/player/land1.wav                  0 0  0
-	BOTH_FORCEWALLREBOUND_LEFT AEV_SOUNDCHAN  2 CHAN_AUTO    sound/weapons/melee/swing%d.mp3	        1 4  0
-	BOTH_FORCEWALLREBOUND_RIGHT AEV_SOUNDCHAN 1 CHAN_AUTO    sound/player/land1.wav                  0 0  0
-	BOTH_FORCEWALLREBOUND_RIGHT AEV_SOUNDCHAN  2 CHAN_AUTO    sound/weapons/melee/swing%d.mp3	       1 4  0
-	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP  1 footstep_l   0
-	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP  7 footstep_r   0
-	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP 11 footstep_l   0
-	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP 17 footstep_r   0
-	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP 23 footstep_l   0
-	BOTH_FORCE_GETUP_B1  AEV_FOOTSTEP 	21 footstep_r        0
-	BOTH_FORCE_GETUP_B1  AEV_FOOTSTEP 	22 footstep_l        0
-	BOTH_FORCE_GETUP_B2  AEV_FOOTSTEP 	24 footstep_r        0
-	BOTH_FORCE_GETUP_B2  AEV_FOOTSTEP 	29 footstep_l        0
-	BOTH_FORCE_GETUP_B3  AEV_FOOTSTEP 	20 footstep_r        0
-	BOTH_FORCE_GETUP_B3  AEV_FOOTSTEP 	21 footstep_l        0
-	BOTH_FORCE_GETUP_B3  AEV_FOOTSTEP 	28 footstep_r        0
-	BOTH_FORCE_GETUP_B5  AEV_FOOTSTEP 	29 footstep_r        0
-	BOTH_FORCE_GETUP_B5  AEV_FOOTSTEP 	31 footstep_l        0
-	BOTH_FORCE_GETUP_B5  AEV_FOOTSTEP 	36 footstep_r        0
-	BOTH_FORCE_GETUP_B5  AEV_FOOTSTEP 	42 footstep_l        0
-	BOTH_FORCE_GETUP_B6  AEV_FOOTSTEP 	 7 footstep_r        0
-	BOTH_FORCE_GETUP_B6  AEV_FOOTSTEP 	38 footstep_l        0
-	BOTH_FORCE_GETUP_B6  AEV_FOOTSTEP 	39 footstep_r        0
-	BOTH_FORCE_GETUP_B6  AEV_FOOTSTEP 	51 footstep_r        0
-	BOTH_FORCE_GETUP_F1  AEV_FOOTSTEP 	26 footstep_r        0
-	BOTH_FORCE_GETUP_F1  AEV_FOOTSTEP 	28 footstep_l        0
-	BOTH_FORCE_GETUP_F2  AEV_FOOTSTEP 	28 footstep_l        0
-	BOTH_FORCE_GETUP_F2  AEV_FOOTSTEP 	31 footstep_r        0
-	BOTH_FORCE_GETUP_F2  AEV_FOOTSTEP 	36 footstep_l        0
-	BOTH_FORCE_GETUP_F2  AEV_FOOTSTEP 	39 footstep_r        0
-	BOTH_FORCE_RAGE 	    AEV_FOOTSTEP 	44 footstep_r        0
-	BOTH_FORCE_RAGE 	    AEV_FOOTSTEP 	45 footstep_l        0
-	BOTH_GETUP_BROLL_B   AEV_FOOTSTEP 	21 footstep_l        0
-	BOTH_GETUP_BROLL_B   AEV_FOOTSTEP 	23 footstep_r        0
-	BOTH_GETUP_BROLL_F   AEV_FOOTSTEP 	15 footstep_r        0
-	BOTH_GETUP_BROLL_F   AEV_FOOTSTEP 	18 footstep_l        0
-	BOTH_GETUP_BROLL_L   AEV_FOOTSTEP 	22 footstep_r        0
-	BOTH_GETUP_BROLL_L   AEV_FOOTSTEP 	25 footstep_l        0
-	BOTH_GETUP_BROLL_R   AEV_FOOTSTEP 	21 footstep_l        0
-	BOTH_GETUP_BROLL_R   AEV_FOOTSTEP 	25 footstep_r        0
-	BOTH_GETUP_CROUCH_B1 AEV_FOOTSTEP 	19 footstep_l        0
-	BOTH_GETUP_CROUCH_B1 AEV_FOOTSTEP 	27 footstep_r        0
-	BOTH_GETUP_CROUCH_F1 AEV_FOOTSTEP 	17 footstep_r        0
-	BOTH_GETUP_CROUCH_F1 AEV_FOOTSTEP 	19 footstep_l        0
-	BOTH_GETUP_FROLL_B   AEV_FOOTSTEP 	24 footstep_l        0
-	BOTH_GETUP_FROLL_B   AEV_FOOTSTEP 	25 footstep_r        0
-	BOTH_GETUP_FROLL_F   AEV_FOOTSTEP 	25 footstep_r        0
-	BOTH_GETUP_FROLL_F   AEV_FOOTSTEP 	26 footstep_l        0
-	BOTH_GETUP_FROLL_L   AEV_FOOTSTEP 	22 footstep_r        0
-	BOTH_GETUP_FROLL_L   AEV_FOOTSTEP 	24 footstep_l        0
-	BOTH_GETUP_FROLL_R   AEV_FOOTSTEP 	22 footstep_l        0
-	BOTH_GETUP_FROLL_R   AEV_FOOTSTEP 	24 footstep_r        0
-	BOTH_JUMP1           AEV_FOOTSTEP   1 footstep_l        0
-	BOTH_JUMPATTACK6     AEV_FOOTSTEP 	16 footstep_r        0
-	BOTH_JUMPATTACK6     AEV_FOOTSTEP 	18 footstep_l        0
-	BOTH_JUMPATTACK6     AEV_FOOTSTEP 	38 footstep_r        0
-	BOTH_JUMPATTACK6     AEV_FOOTSTEP 	40 footstep_l        0
-	BOTH_JUMPATTACK7     AEV_FOOTSTEP 	12 footstep_r        0
-	BOTH_JUMPATTACK7     AEV_FOOTSTEP 	13 footstep_l        0
-	BOTH_KYLE_MISS       AEV_FOOTSTEP 	 8 footstep_r        0
-	BOTH_KYLE_MISS       AEV_FOOTSTEP   13 footstep_l        0
-	BOTH_KYLE_PA_1       AEV_FOOTSTEP  109 footstep_r        0
-	BOTH_KYLE_PA_1       AEV_FOOTSTEP    8 footstep_r        0
-	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  32 CHAN_AUTO         sound/weapons/melee/punch%d.mp3          1 4  0
-	BOTH_KYLE_PA_2       AEV_FOOTSTEP   47 footstep_r        0
-	BOTH_KYLE_PA_2       AEV_FOOTSTEP  112 footstep_l        0
-	BOTH_KYLE_PA_3       AEV_SOUNDCHAN   5 CHAN_AUTO         *jump1.mp3                               0 0  0
-	BOTH_LANDBACK1       AEV_FOOTSTEP 	 1 footstep_l        0
-	BOTH_LANDBACK1       AEV_FOOTSTEP 	 3 footstep_r        0
-	BOTH_LANDLEFT1       AEV_FOOTSTEP 	 1 footstep_r        0
-	BOTH_LANDLEFT1       AEV_FOOTSTEP 	 2 footstep_l        0
-	BOTH_LANDRIGHT1      AEV_FOOTSTEP 	 1 footstep_l        0
-	BOTH_LANDRIGHT1      AEV_FOOTSTEP 	 2 footstep_r        0
-	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN 9 CHAN_AUTO         sound/weapons/melee/punch%d.mp3          1 4  0
-	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN 24 CHAN_AUTO        sound/player/bodyfall_human%d.mp3        1 3  0
-	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN 38 CHAN_AUTO        sound/player/bodyfall_human%d.mp3        1 3  0
-	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN 49 CHAN_AUTO        sound/player/bodyfall_human%d.mp3        1 3  0
-	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN 58 CHAN_AUTO        sound/player/fallsplat.wav               0 0  0
-	BOTH_LK_ST_DL_T_SB_1_W AEV_SOUNDCHAN 5 CHAN_AUTO         sound/weapons/melee/swing%d.mp3	          1 4  0
-	BOTH_LOSE_SABER	     AEV_FOOTSTEP 	  9 footstep_r       0
-	BOTH_LOSE_SABER	     AEV_FOOTSTEP 	 26 footstep_r       0
-	BOTH_LUNGE2_B__T_	   AEV_FOOTSTEP 	 10 footstep_l       0
-	BOTH_PLAYER_PA_1     AEV_FOOTSTEP    36 footstep_l       0
-	BOTH_PLAYER_PA_1     AEV_FOOTSTEP    37 footstep_r       0
-	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN  60 CHAN_AUTO         sound/player/land1.wav                   0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  32 CHAN_AUTO         *pain75.mp3                              0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  47 CHAN_AUTO         sound/weapons/melee/punch%d.mp3          1 4  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  56 CHAN_AUTO         *jump1.mp3                               0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  65 CHAN_AUTO         sound/weapons/melee/punch%d.mp3          1 4  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  66 CHAN_AUTO         sound/player/roll1.wav                   0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  86 CHAN_AUTO         *choke1.mp3                              0 0  0
-	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  95 CHAN_AUTO         sound/player/fallsplat.wav               0 0  0
-	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  97 CHAN_AUTO         sound/player/fallsplat.wav               0 0  0
-	BOTH_PULL_IMPALE_STAB  AEV_FOOTSTEP 	 6 footstep_r        0
-	BOTH_PULL_IMPALE_STAB  AEV_FOOTSTEP 	29 footstep_r        0
-	BOTH_PULL_IMPALE_SWING AEV_FOOTSTEP 15 footstep_l        0
-	BOTH_PULL_IMPALE_SWING AEV_FOOTSTEP 30 footstep_l        0
-	BOTH_RUN1            AEV_FOOTSTEP    8 footstep_heavy_r  0
-	BOTH_RUN1            AEV_FOOTSTEP   20 footstep_heavy_l  0
-	BOTH_RUN2            AEV_FOOTSTEP    8 footstep_heavy_r  0
-	BOTH_RUN2            AEV_FOOTSTEP   20 footstep_heavy_l  0
-	BOTH_RUNBACK1        AEV_FOOTSTEP    3 footstep_heavy_r  0
-	BOTH_RUNBACK1        AEV_FOOTSTEP    8 footstep_heavy_l  0
-	BOTH_RUNBACK2        AEV_FOOTSTEP    3 footstep_heavy_r  0
-	BOTH_RUNBACK2        AEV_FOOTSTEP    8 footstep_heavy_l  0
-	BOTH_RUNBACK_STAFF   AEV_FOOTSTEP    3 footstep_heavy_l  0
-	BOTH_RUNBACK_STAFF   AEV_FOOTSTEP    7 footstep_heavy_r  0
-	BOTH_RUN_DUAL        AEV_FOOTSTEP    8 footstep_heavy_r  0
-	BOTH_RUN_DUAL        AEV_FOOTSTEP   20 footstep_heavy_l  0
-	BOTH_RUN_STAFF       AEV_FOOTSTEP    3 footstep_heavy_r  0
-	BOTH_RUN_STAFF       AEV_FOOTSTEP   10 footstep_heavy_l  0
-	BOTH_STABDOWN 	      AEV_FOOTSTEP 	18 footstep_r        0
-	BOTH_STABDOWN 	      AEV_FOOTSTEP 	20 footstep_l        0
-	BOTH_STABDOWN_DUAL   AEV_FOOTSTEP 	16 footstep_r        0
-	BOTH_STABDOWN_DUAL   AEV_FOOTSTEP 	18 footstep_l        0
-	BOTH_STABDOWN_STAFF  AEV_FOOTSTEP 	18 footstep_l        0
-	BOTH_STABDOWN_STAFF  AEV_FOOTSTEP 	19 footstep_r        0
-	BOTH_TUSKENLUNGE1    AEV_FOOTSTEP 	 5 footstep_l        0
-	BOTH_TUSKENLUNGE1    AEV_FOOTSTEP 	 9 footstep_r        0
-	BOTH_WALK1           AEV_FOOTSTEP    6 footstep_r        0
-	BOTH_WALK1           AEV_FOOTSTEP   20 footstep_l        0
-	BOTH_WALK2           AEV_FOOTSTEP    5 footstep_r        0
-	BOTH_WALK2           AEV_FOOTSTEP   18 footstep_l        0
-	BOTH_WALK7           AEV_FOOTSTEP    5 footstep_l        0
-	BOTH_WALK7           AEV_FOOTSTEP   15 footstep_r        0
-	BOTH_WALKBACK1       AEV_FOOTSTEP    9 footstep_r        0
-	BOTH_WALKBACK1       AEV_FOOTSTEP   22 footstep_l        0
-	BOTH_WALKBACK2       AEV_FOOTSTEP    9 footstep_r        0
-	BOTH_WALKBACK2       AEV_FOOTSTEP   22 footstep_l        0
-	BOTH_WALK_DUAL       AEV_FOOTSTEP    1 footstep_r        0
-	BOTH_WALK_DUAL       AEV_FOOTSTEP    7 footstep_l        0
-	BOTH_WALKBACK_DUAL   AEV_FOOTSTEP    7 footstep_r        0
-	BOTH_WALKBACK_DUAL   AEV_FOOTSTEP    22 footstep_l       0
-	BOTH_WALK_STAFF      AEV_FOOTSTEP    1 footstep_r        0
-	BOTH_WALK_STAFF      AEV_FOOTSTEP    7 footstep_l        0
-	BOTH_WALKBACK_STAFF  AEV_FOOTSTEP    1 footstep_r        0
-	BOTH_WALKBACK_STAFF  AEV_FOOTSTEP    7 footstep_l        0
- BOTH_WALL_FLIP_BACK1 AEV_SOUNDCHAN   1 CHAN_AUTO sound/weapons/melee/swing%d.mp3	  1 4  0
-	BOTH_WALL_FLIP_BACK1 AEV_FOOTSTEP    2 footstep_r        0
-	BOTH_WALL_FLIP_BACK1 AEV_FOOTSTEP    7 footstep_l        0
- BOTH_WALL_FLIP_BACK2 AEV_SOUNDCHAN   1 CHAN_AUTO sound/weapons/melee/swing%d.mp3	  1 4  0
-	BOTH_WALL_FLIP_LEFT  AEV_FOOTSTEP    1 footstep_l        0
-	BOTH_WALL_FLIP_LEFT  AEV_SOUNDCHAN	  2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_WALL_FLIP_LEFT  AEV_FOOTSTEP    4 footstep_r        0
-	BOTH_WALL_FLIP_RIGHT AEV_FOOTSTEP    1 footstep_l        0
-	BOTH_WALL_FLIP_RIGHT AEV_SOUNDCHAN	  2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_WALL_FLIP_RIGHT AEV_FOOTSTEP    4 footstep_r        0
-	BOTH_WALL_RUN_LEFT   AEV_FOOTSTEP   10 footstep_l        0
-	BOTH_WALL_RUN_LEFT   AEV_FOOTSTEP   17 footstep_r        0
-	BOTH_WALL_RUN_LEFT   AEV_FOOTSTEP   26 footstep_l        0
- BOTH_WALL_RUN_LEFT_FLIP AEV_FOOTSTEP  1 footstep_r       0
- BOTH_WALL_RUN_LEFT_FLIP  AEV_SOUNDCHAN	2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_WALL_RUN_RIGHT  AEV_FOOTSTEP    9 footstep_r        0
-	BOTH_WALL_RUN_RIGHT  AEV_FOOTSTEP   17 footstep_l        0
-	BOTH_WALL_RUN_RIGHT  AEV_FOOTSTEP   25 footstep_r        0
- BOTH_WALL_RUN_RIGHT_FLIP AEV_FOOTSTEP  1 footstep_r      0
- BOTH_WALL_RUN_RIGHT_FLIP AEV_SOUNDCHAN	2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-
-	// mb2
-	BOTH_ARC_FORWARD_DIVE 			AEV_SOUNDCHAN	 1	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_ARC_FORWARD_DIVE 			AEV_SOUNDCHAN 	15	CHAN_AUTO	sound/effects/cloth2.mp3			0 0  0
-	BOTH_ARC_FORWARD_DIVE    AEV_FOOTSTEP  22	footstep_r	0
- BOTH_ARC_FORWARD_DIVE    AEV_FOOTSTEP  28	footstep_l	0
- BOTH_BUTTERFLY_FL1 AEV_SOUNDCHAN   1  CHAN_AUTO     *combat%d.mp3                            1 3  0
-	BOTH_BUTTERFLY_FL1 AEV_SOUNDCHAN   2  CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FL1 AEV_SOUNDCHAN   11 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FL1 AEV_SOUNDCHAN   18 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FL1 AEV_SOUNDCHAN   30 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FL1 AEV_SOUNDCHAN   36 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FL1 AEV_SOUNDCHAN   49 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
- BOTH_BUTTERFLY_FR1 AEV_SOUNDCHAN   1  CHAN_AUTO     *combat%d.mp3                            1 3  0
-	BOTH_BUTTERFLY_FR1 AEV_SOUNDCHAN   2  CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FR1 AEV_SOUNDCHAN   11 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FR1 AEV_SOUNDCHAN   18 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FR1 AEV_SOUNDCHAN   30 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FR1 AEV_SOUNDCHAN   36 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
-	BOTH_BUTTERFLY_FR1 AEV_SOUNDCHAN   49 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav  1 9  0
- BOTH_BUTTERFLY_LEFT  AEV_SOUNDCHAN   1  CHAN_AUTO     *combat%d.mp3                            1 3  0
-	BOTH_BUTTERFLY_LEFT  AEV_SOUNDCHAN   9 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
-	BOTH_BUTTERFLY_LEFT  AEV_SOUNDCHAN  16 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
-	BOTH_BUTTERFLY_LEFT  AEV_SOUNDCHAN  22 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
-	BOTH_BUTTERFLY_LEFT  AEV_SOUNDCHAN  29 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
- BOTH_BUTTERFLY_RIGHT AEV_SOUNDCHAN   1  CHAN_AUTO     *combat%d.mp3                            1 3  0
-	BOTH_BUTTERFLY_RIGHT AEV_SOUNDCHAN   9 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
-	BOTH_BUTTERFLY_RIGHT AEV_SOUNDCHAN  16 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
-	BOTH_BUTTERFLY_RIGHT AEV_SOUNDCHAN  22 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
-	BOTH_BUTTERFLY_RIGHT AEV_SOUNDCHAN  29 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
-	BOTH_BUTTERFLY_RIGHT AEV_SOUNDCHAN  35 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
-	BOTH_BUTTERFLY_RIGHT AEV_SOUNDCHAN  45 CHAN_AUTO         sound/weapons/saber/saberhup%d.wav   1 9  0
- BOTH_FLIP_B AEV_SOUNDCHAN	2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_FLIP_F AEV_SOUNDCHAN	2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_FLIP_L AEV_SOUNDCHAN	2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_FLIP_R AEV_SOUNDCHAN	2	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_HOP_B  			AEV_FOOTSTEP   0	footstep_l	0
-	BOTH_HOP_B  			AEV_SOUNDCHAN  2 	CHAN_AUTO		sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_HOP_B  			AEV_SOUNDCHAN  7 	CHAN_AUTO	sound/effects/boot_slide.mp3	1 4  0
-	BOTH_HOP_F  			AEV_FOOTSTEP   0	footstep_l	0
-	BOTH_HOP_F  			AEV_SOUNDCHAN  2 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_HOP_F  			AEV_SOUNDCHAN  7 	CHAN_AUTO	sound/effects/boot_slide.mp3	1 4  0
-	BOTH_HOP_L  			AEV_FOOTSTEP   0	footstep_l	0
-	BOTH_HOP_L  			AEV_SOUNDCHAN  2	 CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_HOP_L  			AEV_SOUNDCHAN  7 	CHAN_AUTO	sound/effects/boot_slide.mp3	1 4  0
-	BOTH_HOP_R  			AEV_FOOTSTEP   0	footstep_l	0
-	BOTH_HOP_R  			AEV_SOUNDCHAN  2	 CHAN_AUTO sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_HOP_R  			AEV_SOUNDCHAN  7 	CHAN_AUTO sound/effects/boot_slide.mp3	1 4  0
- BOTH_MEDITATE 	AEV_SOUNDCHAN 	15	CHAN_AUTO	sound/effects/cloth3.mp3			0 0  0
- BOTH_MEDITATE_END AEV_SOUNDCHAN 	2	CHAN_AUTO	sound/effects/cloth2.mp3			0 0  0
- BOTH_PURPLE_DFA   AEV_SOUNDCHAN   1  CHAN_AUTO     *combat%d.mp3                           1 3  0
-	BOTH_PURPLE_DFA   AEV_SOUNDCHAN  	10	CHAN_AUTO    sound/weapons/saber/saberhup%d.wav      1 9  0
-	BOTH_PURPLE_DFA   AEV_SOUNDCHAN  	25 	CHAN_AUTO   sound/weapons/saber/saberhup%d.wav      1 9  0
-	BOTH_PURPLE_DFA   AEV_SOUNDCHAN  	37 	CHAN_AUTO   sound/weapons/saber/saberhup%d.wav      1 9  0
-	BOTH_ROLL_B  AEV_FOOTSTEP   27	footstep_l	0
-	BOTH_ROLL_B  AEV_FOOTSTEP   31	footstep_r	0
-	BOTH_ROLL_F  AEV_FOOTSTEP   16	footstep_r	0
-	BOTH_ROLL_F  AEV_FOOTSTEP   20 footstep_l	0
-	BOTH_ROLL_L  AEV_FOOTSTEP   16	footstep_r	0
-	BOTH_ROLL_L  AEV_FOOTSTEP   20 footstep_l	0
-	BOTH_ROLL_R  AEV_FOOTSTEP   16	footstep_l	0
-	BOTH_ROLL_R  AEV_FOOTSTEP   20 footstep_r	0
-	BOTH_THROWEE		 			AEV_SOUNDCHAN	 6	CHAN_AUTO	*choke1.mp3							0 0  0
-	BOTH_THROWEE		 			AEV_SOUNDCHAN	 6	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_THROWEE		 			AEV_SOUNDCHAN	15	CHAN_AUTO	sound/player/bodyfall_human%d.mp3	1 3  0
-
-	// mb2 melee
-	BOTH_MELEE_JUMP_KICK			AEV_SOUNDCHAN	0	CHAN_AUTO	*jump1.mp3							0 0  0
-	BOTH_MELEE_JUMP_KICK			AEV_SOUNDCHAN	1	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_MELEE_LEG_SWEEP			AEV_SOUNDCHAN	5	CHAN_AUTO	sound/weapons/melee/swing%d.mp3		 1 4  0
-	BOTH_MELEE_SPIN_KICK_L	AEV_SOUNDCHAN	6	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-	BOTH_MELEE_SPIN_KICK_R	AEV_SOUNDCHAN	6	CHAN_AUTO	sound/weapons/melee/swing%d.mp3			1 4  0
-
-	//BOTH_KICKFINISHER	 			AEV_SOUNDCHAN	10 	CHAN_AUTO	sound/weapons/melee/swing%d.mp3    1 4  0 // not in the animation.cfg
-	
-	// mb2 walk
-	BOTH_MINIGUN_WALK1				AEV_FOOTSTEP	0	footstep_l	0
-	BOTH_MINIGUN_WALK1				AEV_FOOTSTEP	7	footstep_r	0
-	BOTH_MINIGUN_WALKBACK1		AEV_FOOTSTEP	7	footstep_l	0
-	BOTH_MINIGUN_WALKBACK1		AEV_FOOTSTEP	0	footstep_r	0
-	
-	// mb2 walk strafes
-	BOTH_WALK1_STRAFE_L				AEV_FOOTSTEP	9	footstep_l	0
-	BOTH_WALK1_STRAFE_L				AEV_FOOTSTEP	4	footstep_r	0
-	BOTH_WALK1_STRAFE_R				AEV_FOOTSTEP	4	footstep_l	0
-	BOTH_WALK1_STRAFE_R				AEV_FOOTSTEP	9	footstep_r	0
-	BOTH_WALK_DUAL_STRAFE_L			AEV_FOOTSTEP	21	footstep_l	0
-	BOTH_WALK_DUAL_STRAFE_L			AEV_FOOTSTEP	7	footstep_r	0
-	BOTH_WALK_DUAL_STRAFE_R			AEV_FOOTSTEP	7	footstep_l	0
-	BOTH_WALK_DUAL_STRAFE_R			AEV_FOOTSTEP	21	footstep_r	0
-	BOTH_WALK_STAFF_STRAFE_L		AEV_FOOTSTEP	11	footstep_l	0
-	BOTH_WALK_STAFF_STRAFE_L		AEV_FOOTSTEP	4	footstep_r	0
-	BOTH_WALK_STAFF_STRAFE_R		AEV_FOOTSTEP	4	footstep_l	0
-	BOTH_WALK_STAFF_STRAFE_R		AEV_FOOTSTEP	11	footstep_r	0
-	BOTH_MINIGUN_WALK1_STRAFE_L		AEV_FOOTSTEP	8	footstep_l	0
-	BOTH_MINIGUN_WALK1_STRAFE_L		AEV_FOOTSTEP	13	footstep_r	0
-	BOTH_MINIGUN_WALK1_STRAFE_R		AEV_FOOTSTEP	5	footstep_l	0
-	BOTH_MINIGUN_WALK1_STRAFE_R		AEV_FOOTSTEP	11	footstep_r	0
-	
-	// mb2 run
-	BOTH_WOOKIEE_RAGE_RUN			AEV_FOOTSTEP	5	footstep_heavy_r	0
-	BOTH_WOOKIEE_RAGE_RUN			AEV_FOOTSTEP	17	footstep_heavy_l	0
-	
-	// mb2 run strafes
-	BOTH_RUN1_STRAFE_L				AEV_FOOTSTEP	0	footstep_heavy_l	0
-	BOTH_RUN1_STRAFE_L				AEV_FOOTSTEP	7	footstep_heavy_r	0
-	BOTH_RUN1_STRAFE_R				AEV_FOOTSTEP	7	footstep_heavy_l	0
-	BOTH_RUN1_STRAFE_R				AEV_FOOTSTEP	0	footstep_heavy_r	0
-	BOTH_RUN2_STRAFE_L				AEV_FOOTSTEP	0	footstep_heavy_l	0
-	BOTH_RUN2_STRAFE_L				AEV_FOOTSTEP	7	footstep_heavy_r	0
-	BOTH_RUN2_STRAFE_R				AEV_FOOTSTEP	7	footstep_heavy_l	0
-	BOTH_RUN2_STRAFE_R				AEV_FOOTSTEP	0	footstep_heavy_r	0
-	BOTH_RUN_DUAL_STRAFE_L			AEV_FOOTSTEP	0	footstep_heavy_l	0
-	BOTH_RUN_DUAL_STRAFE_L			AEV_FOOTSTEP	7	footstep_heavy_r	0
-	BOTH_RUN_DUAL_STRAFE_R			AEV_FOOTSTEP	7	footstep_heavy_l	0
-	BOTH_RUN_DUAL_STRAFE_R			AEV_FOOTSTEP	0	footstep_heavy_r	0	
-	BOTH_RUN_STAFF_STRAFE_L		AEV_FOOTSTEP	0	footstep_heavy_l	0
-	BOTH_RUN_STAFF_STRAFE_L		AEV_FOOTSTEP	7	footstep_heavy_r	0
-	BOTH_RUN_STAFF_STRAFE_R		AEV_FOOTSTEP	7	footstep_heavy_l	0
-	BOTH_RUN_STAFF_STRAFE_R		AEV_FOOTSTEP	0	footstep_heavy_r	0
-	BOTH_WOOKIEE_RAGE_RUN_STRAFE_L	AEV_FOOTSTEP	21	footstep_heavy_l	0
-	BOTH_WOOKIEE_RAGE_RUN_STRAFE_L	AEV_FOOTSTEP	8	footstep_heavy_r	0
-	BOTH_WOOKIEE_RAGE_RUN_STRAFE_R	AEV_FOOTSTEP	8	footstep_heavy_l	0
-	BOTH_WOOKIEE_RAGE_RUN_STRAFE_R	AEV_FOOTSTEP	21	footstep_heavy_r	0
+//Saber Special
+BOTH_A1_SPECIAL         AEV_FOOTSTEP   7 footstep_l 0
+BOTH_A1_SPECIAL         AEV_FOOTSTEP  56 footstep_l 0
+BOTH_A2_SPECIAL         AEV_FOOTSTEP   7 footstep_r 0
+BOTH_A2_SPECIAL         AEV_FOOTSTEP  15 footstep_l 0
+BOTH_A2_SPECIAL         AEV_FOOTSTEP  42 footstep_r 0
+BOTH_A2_SPECIAL         AEV_FOOTSTEP  47 footstep_l 0
+BOTH_A2_STABBACK1       AEV_FOOTSTEP  12 footstep_r 0
+BOTH_A2_STABBACK1       AEV_FOOTSTEP  39 footstep_r 0
+BOTH_A3_SPECIAL         AEV_FOOTSTEP   8 footstep_l 0
+BOTH_A3_SPECIAL         AEV_FOOTSTEP  21 footstep_r 0
+BOTH_A3_SPECIAL         AEV_FOOTSTEP  30 footstep_l 0
+BOTH_A7_HILT            AEV_FOOTSTEP   8 footstep_l 0
+BOTH_A7_HILT            AEV_SOUNDCHAN 11 CHAN_WEAPON sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_HILT            AEV_FOOTSTEP  25 footstep_l 0
+BOTH_A7_KICK_BF         AEV_FOOTSTEP  37 footstep_l 0
+BOTH_A7_KICK_BF         AEV_FOOTSTEP  39 footstep_r 0
+BOTH_A7_KICK_BF_STOP    AEV_FOOTSTEP   9 footstep_l 0
+BOTH_A7_KICK_BF_STOP    AEV_FOOTSTEP  10 footstep_r 0
+BOTH_A7_KICK_RL         AEV_FOOTSTEP  13 footstep_r 0
+BOTH_A7_KICK_S          AEV_FOOTSTEP  21 footstep_l 0
+BOTH_A7_KICK_S          AEV_FOOTSTEP  23 footstep_r 0
+BOTH_A7_SOULCAL         AEV_FOOTSTEP  11 footstep_l 0
+BOTH_A7_SOULCAL         AEV_FOOTSTEP  20 footstep_r 0
+BOTH_A7_SOULCAL         AEV_SOUNDCHAN 27 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_A7_SOULCAL         AEV_FOOTSTEP  32 footstep_l 0
+BOTH_A7_SOULCAL         AEV_FOOTSTEP  33 footstep_r 0
+BOTH_A7_SOULCAL         AEV_FOOTSTEP  39 footstep_l 0
+BOTH_A7_SOULCAL         AEV_FOOTSTEP  45 footstep_r 0
+BOTH_ARIAL_LEFT         AEV_FOOTSTEP   4 footstep_l 0
+BOTH_ARIAL_LEFT         AEV_FOOTSTEP  18 footstep_r 0
+BOTH_ARIAL_LEFT         AEV_FOOTSTEP  21 footstep_l 0
+BOTH_ARIAL_RIGHT        AEV_FOOTSTEP   4 footstep_r 0
+BOTH_ARIAL_RIGHT        AEV_FOOTSTEP  18 footstep_l 0
+BOTH_ARIAL_RIGHT        AEV_FOOTSTEP  21 footstep_r 0
+BOTH_ATTACK_BACK        AEV_FOOTSTEP   1 footstep_L 0
+BOTH_ATTACK_BACK        AEV_FOOTSTEP  13 footstep_r 0
+BOTH_ATTACK_BACK        AEV_FOOTSTEP  21 footstep_l 0
+BOTH_ATTACK_BACK        AEV_FOOTSTEP  27 footstep_r 0
+BOTH_BUTTERFLY_FL1      AEV_FOOTSTEP   6 footstep_r 0
+BOTH_BUTTERFLY_FL1      AEV_FOOTSTEP  13 footstep_l 0
+BOTH_BUTTERFLY_FL1      AEV_FOOTSTEP  31 footstep_r 0
+BOTH_BUTTERFLY_FL1      AEV_FOOTSTEP  37 footstep_l 0
+BOTH_BUTTERFLY_FL1      AEV_FOOTSTEP  45 footstep_r 0
+BOTH_BUTTERFLY_FL1      AEV_FOOTSTEP  52 footstep_l 0
+BOTH_BUTTERFLY_FR1      AEV_FOOTSTEP   6 footstep_l 0
+BOTH_BUTTERFLY_FR1      AEV_FOOTSTEP  13 footstep_r 0
+BOTH_BUTTERFLY_FR1      AEV_FOOTSTEP  32 footstep_l 0
+BOTH_BUTTERFLY_FR1      AEV_FOOTSTEP  36 footstep_r 0
+BOTH_BUTTERFLY_FR1      AEV_FOOTSTEP  45 footstep_l 0
+BOTH_BUTTERFLY_FR1      AEV_FOOTSTEP  52 footstep_r 0
+BOTH_BUTTERFLY_LEFT     AEV_FOOTSTEP  11 footstep_l 0
+BOTH_BUTTERFLY_LEFT     AEV_FOOTSTEP  29 footstep_l 0
+BOTH_BUTTERFLY_LEFT     AEV_FOOTSTEP  35 footstep_r 0
+BOTH_BUTTERFLY_LEFT     AEV_FOOTSTEP  44 footstep_l 0
+BOTH_BUTTERFLY_RIGHT    AEV_FOOTSTEP   6 footstep_l 0
+BOTH_BUTTERFLY_RIGHT    AEV_FOOTSTEP  13 footstep_r 0
+BOTH_BUTTERFLY_RIGHT    AEV_FOOTSTEP  32 footstep_l 0
+BOTH_BUTTERFLY_RIGHT    AEV_FOOTSTEP  36 footstep_r 0
+BOTH_BUTTERFLY_RIGHT    AEV_FOOTSTEP  44 footstep_l 0
+BOTH_BUTTERFLY_RIGHT    AEV_FOOTSTEP  52 footstep_r 0
+BOTH_CARTWHEEL_LEFT     AEV_FOOTSTEP   2 footstep_l 0
+BOTH_CARTWHEEL_LEFT     AEV_FOOTSTEP  15 footstep_r 0
+BOTH_CARTWHEEL_LEFT     AEV_FOOTSTEP  16 footstep_l 0
+BOTH_CARTWHEEL_RIGHT    AEV_FOOTSTEP   2 footstep_r 0
+BOTH_CARTWHEEL_RIGHT    AEV_FOOTSTEP  15 footstep_l 0
+BOTH_CARTWHEEL_RIGHT    AEV_FOOTSTEP  16 footstep_r 0
+BOTH_JUMPATTACK6        AEV_FOOTSTEP  16 footstep_r 0
+BOTH_JUMPATTACK6        AEV_FOOTSTEP  18 footstep_l 0
+BOTH_JUMPATTACK6        AEV_FOOTSTEP  38 footstep_r 0
+BOTH_JUMPATTACK6        AEV_FOOTSTEP  40 footstep_l 0
+BOTH_JUMPATTACK7        AEV_FOOTSTEP  12 footstep_r 0
+BOTH_JUMPATTACK7        AEV_FOOTSTEP  13 footstep_l 0
+BOTH_JUMPFLIPSLASHDOWN1 AEV_FOOTSTEP  38 footstep_heavy_r 0
+BOTH_LUNGE2_B__T_       AEV_SOUNDCHAN  1 CHAN_AUTO sound/effects/woosh2.mp3 0 0 0
+BOTH_LUNGE2_B__T_       AEV_FOOTSTEP  10 footstep_l 0
+BOTH_PULL_IMPALE_STAB   AEV_SOUNDCHAN  1 CHAN_AUTO sound/effects/woosh2.mp3 0 0 0
+BOTH_PULL_IMPALE_STAB   AEV_FOOTSTEP   6 footstep_r 0
+BOTH_PULL_IMPALE_STAB   AEV_FOOTSTEP  29 footstep_r 0
+BOTH_PULL_IMPALE_SWING  AEV_SOUNDCHAN  1 CHAN_AUTO sound/effects/woosh2.mp3 0 0 0
+BOTH_PULL_IMPALE_SWING  AEV_FOOTSTEP  15 footstep_l 0
+BOTH_PULL_IMPALE_SWING  AEV_FOOTSTEP  30 footstep_l 0
+BOTH_PURPLE_DFA         AEV_SOUNDCHAN  1 CHAN_VOICE *combat%d.mp3 1 3 0
+BOTH_PURPLE_DFA         AEV_SOUNDCHAN 33 CHAN_AUTO sound/weapons/saber/saberhup%d.wav 1 9 0
+BOTH_STABDOWN           AEV_FOOTSTEP  18 footstep_r 0
+BOTH_STABDOWN           AEV_FOOTSTEP  20 footstep_l 0
+BOTH_STABDOWN_DUAL      AEV_FOOTSTEP  16 footstep_r 0
+BOTH_STABDOWN_DUAL      AEV_FOOTSTEP  18 footstep_l 0
+BOTH_STABDOWN_STAFF     AEV_FOOTSTEP  18 footstep_l 0
+BOTH_STABDOWN_STAFF     AEV_FOOTSTEP  19 footstep_r 0
+//Gesture
+BOTH_ALORA_SPIN_SLASH     AEV_FOOTSTEP    1 footstep_l 0
+BOTH_ALORA_SPIN_SLASH     AEV_FOOTSTEP   21 footstep_heavy_r 0
+BOTH_ALORA_SPIN_SLASH     AEV_FOOTSTEP   42 footstep_heavy_r 0
+BOTH_ALORA_TAUNT          AEV_FOOTSTEP    4 footstep_r 0
+BOTH_ALORA_TAUNT          AEV_FOOTSTEP   96 footstep_r 0
+BOTH_BOW                  AEV_FOOTSTEP    8 footstep_l 0
+BOTH_COLLAPSED_GETUP      AEV_FOOTSTEP    5 footstep_l 0
+BOTH_COLLAPSED_GETUP      AEV_FOOTSTEP   15 footstep_r 0
+BOTH_COME_ON1             AEV_FOOTSTEP    4 footstep_r 0
+BOTH_COWER1               AEV_FOOTSTEP    1 footstep_l 0
+BOTH_COWER1               AEV_FOOTSTEP    5 footstep_r 0
+BOTH_COWER1               AEV_FOOTSTEP   17 footstep_l 0
+BOTH_COWER1               AEV_FOOTSTEP   28 footstep_r 0
+BOTH_COWER1               AEV_FOOTSTEP   38 footstep_l 0
+BOTH_COWER1_START         AEV_FOOTSTEP    6 footstep_l 0
+BOTH_COWER1_STOP          AEV_FOOTSTEP   42 footstep_l 0
+BOTH_CROUCH3              AEV_FOOTSTEP   18 footstep_r 0
+BOTH_DUAL_TAUNT           AEV_FOOTSTEP   19 footstep_l 0
+BOTH_DUAL_TAUNT           AEV_FOOTSTEP   76 footstep_l 0
+BOTH_FAINT                AEV_FOOTSTEP   41 footstep_l 0
+BOTH_GESTURE1             AEV_FOOTSTEP    1 footstep_r 0
+BOTH_GESTURE1             AEV_FOOTSTEP   23 footstep_l 0
+BOTH_GESTURE1             AEV_FOOTSTEP  128 footstep_l 0
+BOTH_HUGGEESTOP1          AEV_SOUNDCHAN   7 CHAN_AUTO sound/player/land1.wav 0 0 0
+BOTH_HUGGER1              AEV_FOOTSTEP    4 footstep_r 0
+BOTH_HUGGER1              AEV_FOOTSTEP    6 footstep_l 0
+BOTH_INJURED_TO_COLLAPSED AEV_SOUNDCHAN  11 CHAN_BODY sound/effects/cloth2.mp3 0 0 0
+BOTH_LOSE_SABER           AEV_FOOTSTEP    9 footstep_r 0
+BOTH_LOSE_SABER           AEV_FOOTSTEP   26 footstep_r 0
+BOTH_MAUL_TAUNT           AEV_FOOTSTEP    6 footstep_heavy_l 0
+BOTH_MAUL_TAUNT           AEV_FOOTSTEP   26 footstep_l 0
+BOTH_MAUL_TAUNT           AEV_FOOTSTEP   29 footstep_r 0
+BOTH_MEDITATE             AEV_FOOTSTEP    1 footstep_l 0
+BOTH_MEDITATE             AEV_SOUNDCHAN  15 CHAN_AUTO sound/effects/cloth3.mp3 0 0 0
+BOTH_MEDITATE_END         AEV_SOUNDCHAN   2 CHAN_AUTO sound/effects/cloth2.mp3 0 0 0
+BOTH_MEDITATE_END         AEV_FOOTSTEP    4 footstep_r 0
+BOTH_MEDITATE_END         AEV_FOOTSTEP   10 footstep_l 0
+BOTH_SABERKILLER1         AEV_FOOTSTEP    5 footstep_l 0
+BOTH_SABERKILLER1         AEV_FOOTSTEP   21 footstep_r 0
+BOTH_SABERTHROW1START     AEV_FOOTSTEP   12 footstep_r 0
+BOTH_SHOWOFF_STRONG       AEV_FOOTSTEP    1 footstep_r 0
+BOTH_STEADYSELF1          AEV_FOOTSTEP    5 footstep_r 0
+BOTH_STEADYSELF1END       AEV_FOOTSTEP    2 footstep_r 0
+BOTH_TAVION_SCEPTERGROUND AEV_FOOTSTEP   26 footstep_heavy_l 0
+BOTH_TAVION_SWORDPOWER    AEV_FOOTSTEP    9 footstep_r 0
+BOTH_TAVION_SWORDPOWER    AEV_FOOTSTEP   17 footstep_l 0
+BOTH_TAVION_SWORDPOWER    AEV_FOOTSTEP   42 footstep_r 0
+BOTH_TAVION_SWORDPOWER    AEV_FOOTSTEP   46 footstep_l 0
+BOTH_TAVION_SWORDPOWER    AEV_FOOTSTEP   51 footstep_r 0
+BOTH_VICTORY_DUAL         AEV_FOOTSTEP   25 footstep_r 0
+BOTH_VICTORY_FAST         AEV_FOOTSTEP    1 footstep_r 0
+BOTH_VICTORY_FAST         AEV_FOOTSTEP   45 footstep_r 0
+BOTH_VICTORY_MEDIUM       AEV_FOOTSTEP   15 footstep_r 0
+BOTH_VICTORY_MEDIUM       AEV_FOOTSTEP   56 footstep_r 0
+BOTH_VICTORY_STAFF        AEV_FOOTSTEP   26 footstep_r 0
+BOTH_VICTORY_STAFF        AEV_SOUNDCHAN  30 CHAN_WEAPON sound/weapons/saber/saberhit%d.mp3 1 3 0
+BOTH_VICTORY_STRONG       AEV_SOUNDCHAN  13 CHAN_WEAPON sound/weapons/saber/saberhit%d.mp3 1 3 0
+BOTH_VICTORY_STRONG       AEV_FOOTSTEP   42 footstep_r 0
+//Death, Fall
+BOTH_DEATH1          AEV_SOUNDCHAN 13 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH10         AEV_SOUNDCHAN 26 CHAN_AUTO sound/movers/objects/objecthit.wav 0 0 0
+BOTH_DEATH10         AEV_SOUNDCHAN 52 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH11         AEV_SOUNDCHAN 19 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH11         AEV_SOUNDCHAN 40 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH12         AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DEATH12         AEV_SOUNDCHAN 14 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH12         AEV_SOUNDCHAN 27 CHAN_AUTO sound/movers/objects/objecthit.wav 0 0 0
+BOTH_DEATH13         AEV_FOOTSTEP   8 footstep_r 0
+BOTH_DEATH13         AEV_FOOTSTEP  13 footstep_l 0
+BOTH_DEATH13         AEV_FOOTSTEP  19 footstep_r 0
+BOTH_DEATH13         AEV_SOUNDCHAN 33 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH13         AEV_SOUNDCHAN 49 CHAN_AUTO sound/movers/objects/objecthit.wav 0 0 0
+BOTH_DEATH14         AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DEATH14         AEV_SOUNDCHAN 24 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH15         AEV_SOUNDCHAN 15 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH15         AEV_SOUNDCHAN 43 CHAN_AUTO sound/movers/objects/objecthit.wav 0 0 0
+BOTH_DEATH16         AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DEATH16         AEV_SOUNDCHAN 14 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH17         AEV_FOOTSTEP   9 footstep_r 0
+BOTH_DEATH17         AEV_FOOTSTEP  32 footstep_r 0
+BOTH_DEATH17         AEV_SOUNDCHAN 56 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH18         AEV_FOOTSTEP   5 footstep_r 0
+BOTH_DEATH18         AEV_SOUNDCHAN 21 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH18         AEV_SOUNDCHAN 38 CHAN_AUTO sound/movers/objects/objecthit.wav 0 0 0
+BOTH_DEATH18         AEV_SOUNDCHAN 38 CHAN_AUTO sound/movers/objects/objecthit.wav 0 0 0
+BOTH_DEATH18         AEV_SOUNDCHAN 68 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH19         AEV_FOOTSTEP   6 footstep_r 0
+BOTH_DEATH19         AEV_SOUNDCHAN 21 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH19         AEV_SOUNDCHAN 68 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH2          AEV_SOUNDCHAN 13 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH20         AEV_SOUNDCHAN 33 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH21         AEV_SOUNDCHAN 34 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH22         AEV_SOUNDCHAN  6 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH23         AEV_SOUNDCHAN  6 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH24         AEV_FOOTSTEP   2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DEATH24         AEV_SOUNDCHAN 15 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH25         AEV_SOUNDCHAN 15 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH3          AEV_SOUNDCHAN  2 CHAN_AUTO sound/interface/choose_torso.mp3 0 0 0
+BOTH_DEATH3          AEV_SOUNDCHAN 15 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH4          AEV_SOUNDCHAN  2 CHAN_AUTO sound/effects/cloth3.mp3 0 0 0
+BOTH_DEATH4          AEV_SOUNDCHAN 19 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH5          AEV_SOUNDCHAN  2 CHAN_AUTO sound/effects/cloth3.mp3 0 0 0
+BOTH_DEATH5          AEV_SOUNDCHAN 19 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH6          AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DEATH6          AEV_SOUNDCHAN 14 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH7          AEV_SOUNDCHAN  2 CHAN_AUTO sound/interface/choose_torso.mp3 0 0 0
+BOTH_DEATH7          AEV_SOUNDCHAN 13 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH8          AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DEATH8          AEV_SOUNDCHAN 17 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH9          AEV_SOUNDCHAN 21 CHAN_AUTO sound/movers/objects/objecthit.wav 0 0 0
+BOTH_DEATH9          AEV_SOUNDCHAN 40 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH_CROUCHED  AEV_SOUNDCHAN  5 CHAN_AUTO sound/movers/objects/objecthit.wav 0 0 0
+BOTH_DEATH_CROUCHED  AEV_SOUNDCHAN 18 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH_SPIN_180  AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_DEATH_SPIN_180  AEV_SOUNDCHAN 12 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH_SPIN_90_L AEV_SOUNDCHAN 12 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+BOTH_DEATH_SPIN_90_R AEV_SOUNDCHAN 12 CHAN_AUTO sound/player/bodyfall_human%d.wav 1 3 0
+//Movement
+BOTH_ARC_FORWARD_DIVE         AEV_SOUNDCHAN  1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_ARC_FORWARD_DIVE         AEV_SOUNDCHAN 10 CHAN_AUTO sound/player/roll1.wav 0 0 0
+BOTH_ARC_FORWARD_DIVE         AEV_FOOTSTEP  22 footstep_r 0
+BOTH_ARC_FORWARD_DIVE         AEV_FOOTSTEP  28 footstep_l 0
+BOTH_BACK_FLIP_UP        AEV_FOOTSTEP  20 footstep_r 0
+BOTH_BACK_FLIP_UP        AEV_FOOTSTEP  22 footstep_l 0
+BOTH_FLIP_B                   AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FLIP_BACK1               AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FLIP_BACK2               AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FLIP_BACK3               AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FLIP_F                   AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FLIP_L                   AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FLIP_LEFT                AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FLIP_R                   AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_FORCE_GETUP_B1      AEV_FOOTSTEP  21 footstep_r 0
+BOTH_FORCE_GETUP_B1      AEV_FOOTSTEP  22 footstep_l 0
+BOTH_FORCE_GETUP_B2      AEV_FOOTSTEP  24 footstep_r 0
+BOTH_FORCE_GETUP_B2      AEV_FOOTSTEP  29 footstep_l 0
+BOTH_FORCE_GETUP_B3      AEV_FOOTSTEP  20 footstep_r 0
+BOTH_FORCE_GETUP_B3      AEV_FOOTSTEP  21 footstep_l 0
+BOTH_FORCE_GETUP_B3      AEV_FOOTSTEP  28 footstep_r 0
+BOTH_FORCE_GETUP_B5      AEV_FOOTSTEP  29 footstep_r 0
+BOTH_FORCE_GETUP_B5      AEV_FOOTSTEP  31 footstep_l 0
+BOTH_FORCE_GETUP_B5      AEV_FOOTSTEP  36 footstep_r 0
+BOTH_FORCE_GETUP_B5      AEV_FOOTSTEP  42 footstep_l 0
+BOTH_FORCE_GETUP_B6      AEV_FOOTSTEP   7 footstep_r 0
+BOTH_FORCE_GETUP_B6      AEV_FOOTSTEP  38 footstep_l 0
+BOTH_FORCE_GETUP_B6      AEV_FOOTSTEP  39 footstep_r 0
+BOTH_FORCE_GETUP_B6      AEV_FOOTSTEP  51 footstep_r 0
+BOTH_FORCE_GETUP_F1      AEV_FOOTSTEP  26 footstep_r 0
+BOTH_FORCE_GETUP_F1      AEV_FOOTSTEP  28 footstep_l 0
+BOTH_FORCE_GETUP_F2      AEV_FOOTSTEP  28 footstep_l 0
+BOTH_FORCE_GETUP_F2      AEV_FOOTSTEP  31 footstep_r 0
+BOTH_FORCE_GETUP_F2      AEV_FOOTSTEP  36 footstep_l 0
+BOTH_FORCE_GETUP_F2      AEV_FOOTSTEP  39 footstep_r 0
+BOTH_FORCEJUMP1          AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCEJUMPBACK1      AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCEJUMPLEFT1      AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCEJUMPRIGHT1     AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCELAND1               AEV_FOOTSTEP   2 footstep_l 0
+BOTH_FORCELAND1               AEV_FOOTSTEP   3 footstep_r 0
+BOTH_FORCELANDBACK1           AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCELANDBACK1           AEV_FOOTSTEP   4 footstep_r 0
+BOTH_FORCELANDLEFT1           AEV_FOOTSTEP   2 footstep_r 0
+BOTH_FORCELANDLEFT1           AEV_FOOTSTEP   3 footstep_l 0
+BOTH_FORCELANDRIGHT1          AEV_FOOTSTEP   2 footstep_l 0
+BOTH_FORCELANDRIGHT1          AEV_FOOTSTEP   3 footstep_r 0
+BOTH_FORCELEAP2_T__B_         AEV_FOOTSTEP  27 footstep_r 0
+BOTH_FORCELEAP2_T__B_         AEV_FOOTSTEP  28 footstep_l 0
+BOTH_FORCELONGLEAP_LAND       AEV_SOUNDCHAN  1 CHAN_AUTO sound/effects/boot_slide.mp3 1 4 0
+BOTH_FORCEWALLREBOUND_BACK    AEV_FOOTSTEP   1 footstep_r 0
+BOTH_FORCEWALLREBOUND_FORWARD AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCEWALLREBOUND_LEFT    AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCEWALLREBOUND_RIGHT   AEV_FOOTSTEP   1 footstep_r 0
+BOTH_FORCEWALLRELEASE_BACK    AEV_FOOTSTEP   1 footstep_r 0
+BOTH_FORCEWALLRELEASE_FORWARD AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCEWALLRELEASE_LEFT    AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCEWALLRELEASE_RIGHT   AEV_FOOTSTEP   1 footstep_r 0
+BOTH_FORCEWALLRUNFLIP_START   AEV_FOOTSTEP   1 footstep_l 0
+BOTH_FORCEWALLRUNFLIP_START   AEV_FOOTSTEP   7 footstep_r 0
+BOTH_FORCEWALLRUNFLIP_START   AEV_FOOTSTEP  11 footstep_l 0
+BOTH_FORCEWALLRUNFLIP_START   AEV_FOOTSTEP  17 footstep_r 0
+BOTH_FORCEWALLRUNFLIP_START   AEV_FOOTSTEP  23 footstep_l 0
+BOTH_GETUP_BROLL_B       AEV_FOOTSTEP  21 footstep_l 0
+BOTH_GETUP_BROLL_B       AEV_FOOTSTEP  23 footstep_r 0
+BOTH_GETUP_BROLL_F       AEV_FOOTSTEP  15 footstep_r 0
+BOTH_GETUP_BROLL_F       AEV_FOOTSTEP  18 footstep_l 0
+BOTH_GETUP_BROLL_L       AEV_FOOTSTEP  22 footstep_r 0
+BOTH_GETUP_BROLL_L       AEV_FOOTSTEP  25 footstep_l 0
+BOTH_GETUP_BROLL_R       AEV_FOOTSTEP  21 footstep_l 0
+BOTH_GETUP_BROLL_R       AEV_FOOTSTEP  25 footstep_r 0
+BOTH_GETUP_CROUCH_B1     AEV_FOOTSTEP  19 footstep_l 0
+BOTH_GETUP_CROUCH_B1     AEV_FOOTSTEP  27 footstep_r 0
+BOTH_GETUP_CROUCH_F1     AEV_FOOTSTEP  17 footstep_r 0
+BOTH_GETUP_CROUCH_F1     AEV_FOOTSTEP  19 footstep_l 0
+BOTH_GETUP_FROLL_B       AEV_FOOTSTEP  24 footstep_l 0
+BOTH_GETUP_FROLL_B       AEV_FOOTSTEP  25 footstep_r 0
+BOTH_GETUP_FROLL_F       AEV_FOOTSTEP  25 footstep_r 0
+BOTH_GETUP_FROLL_F       AEV_FOOTSTEP  26 footstep_l 0
+BOTH_GETUP_FROLL_L       AEV_FOOTSTEP  22 footstep_r 0
+BOTH_GETUP_FROLL_L       AEV_FOOTSTEP  24 footstep_l 0
+BOTH_GETUP_FROLL_R       AEV_FOOTSTEP  22 footstep_l 0
+BOTH_GETUP_FROLL_R       AEV_FOOTSTEP  24 footstep_r 0
+BOTH_HOP_B                    AEV_FOOTSTEP   2 footstep_l 0
+BOTH_HOP_B                    AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_HOP_B                    AEV_EFFECT     3 emitter/smoke_trail
+BOTH_HOP_B                    AEV_FOOTSTEP   8 footstep_l 0
+BOTH_HOP_B                    AEV_FOOTSTEP  11 footstep_r 0
+BOTH_HOP_F                    AEV_FOOTSTEP   2 footstep_r 0
+BOTH_HOP_F                    AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_HOP_F                    AEV_EFFECT     3 emitter/smoke_trail
+BOTH_HOP_F                    AEV_FOOTSTEP   8 footstep_r 0
+BOTH_HOP_F                    AEV_FOOTSTEP  12 footstep_l 0
+BOTH_HOP_L                    AEV_FOOTSTEP   2 footstep_r 0
+BOTH_HOP_L                    AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_HOP_L                    AEV_EFFECT     3 emitter/smoke_trail
+BOTH_HOP_L                    AEV_FOOTSTEP   8 footstep_r 0
+BOTH_HOP_L                    AEV_FOOTSTEP  11 footstep_l 0
+BOTH_HOP_R                    AEV_FOOTSTEP   2 footstep_l 0
+BOTH_HOP_R                    AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_HOP_R                    AEV_EFFECT     3 emitter/smoke_trail
+BOTH_HOP_R                    AEV_FOOTSTEP   8 footstep_l 0
+BOTH_HOP_R                    AEV_FOOTSTEP  12 footstep_r 0
+BOTH_JUMP1                    AEV_FOOTSTEP   1 footstep_r 0
+BOTH_JUMPBACK1                AEV_FOOTSTEP   1 footstep_r 0
+BOTH_JUMPLEFT1                AEV_FOOTSTEP   1 footstep_r 0
+BOTH_JUMPRIGHT1               AEV_FOOTSTEP   1 footstep_l 0
+BOTH_LAND1               AEV_FOOTSTEP   1 footstep_heavy_r 0
+BOTH_LAND1               AEV_FOOTSTEP   2 footstep_heavy_l 0
+BOTH_LANDBACK1           AEV_FOOTSTEP   1 footstep_heavy_l 0
+BOTH_LANDBACK1           AEV_FOOTSTEP   3 footstep_heavy_r 0
+BOTH_LANDLEFT1           AEV_FOOTSTEP   1 footstep_heavy_r 0
+BOTH_LANDLEFT1           AEV_FOOTSTEP   2 footstep_heavy_l 0
+BOTH_LANDRIGHT1          AEV_FOOTSTEP   1 footstep_heavy_l 0
+BOTH_LANDRIGHT1          AEV_FOOTSTEP   2 footstep_heavy_r 0
+BOTH_ROLL_B                   AEV_FOOTSTEP  27 footstep_l 0
+BOTH_ROLL_B                   AEV_FOOTSTEP  31 footstep_r 0
+BOTH_ROLL_F                   AEV_FOOTSTEP  16 footstep_r 0
+BOTH_ROLL_F                   AEV_FOOTSTEP  20 footstep_l 0
+BOTH_ROLL_L                   AEV_FOOTSTEP  16 footstep_r 0
+BOTH_ROLL_L                   AEV_FOOTSTEP  20 footstep_l 0
+BOTH_ROLL_R                   AEV_FOOTSTEP  16 footstep_l 0
+BOTH_ROLL_R                   AEV_FOOTSTEP  20 footstep_r 0
+BOTH_TUSKENLUNGE1             AEV_FOOTSTEP   5 footstep_l 0
+BOTH_TUSKENLUNGE1             AEV_FOOTSTEP   9 footstep_r 0
+BOTH_WALL_FLIP_BACK1     AEV_FOOTSTEP   2 footstep_heavy_r 0
+BOTH_WALL_FLIP_BACK1     AEV_FOOTSTEP   7 footstep_heavy_l 0
+BOTH_WALL_FLIP_BACK1     AEV_SOUNDCHAN  9 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WALL_FLIP_BACK2     AEV_FOOTSTEP   2 footstep_heavy_r 0
+BOTH_WALL_FLIP_BACK2     AEV_FOOTSTEP   7 footstep_heavy_l 0
+BOTH_WALL_FLIP_BACK2     AEV_SOUNDCHAN  9 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WALL_FLIP_LEFT      AEV_FOOTSTEP   1 footstep_heavy_l 0
+BOTH_WALL_FLIP_LEFT      AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WALL_FLIP_LEFT      AEV_FOOTSTEP   4 footstep_heavy_r 0
+BOTH_WALL_FLIP_RIGHT     AEV_FOOTSTEP   1 footstep_heavy_l 0
+BOTH_WALL_FLIP_RIGHT     AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WALL_FLIP_RIGHT     AEV_FOOTSTEP   4 footstep_heavy_r 0
+BOTH_WALL_RUN_LEFT       AEV_FOOTSTEP   1 footstep_heavy_r 0
+BOTH_WALL_RUN_LEFT       AEV_FOOTSTEP   5 footstep_heavy_l 0
+BOTH_WALL_RUN_LEFT       AEV_FOOTSTEP  13 footstep_heavy_r 0
+BOTH_WALL_RUN_LEFT       AEV_FOOTSTEP  21 footstep_heavy_l 0
+BOTH_WALL_RUN_LEFT_FLIP  AEV_FOOTSTEP   1 footstep_heavy_l 0
+BOTH_WALL_RUN_LEFT_FLIP  AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_WALL_RUN_RIGHT      AEV_FOOTSTEP   1 footstep_heavy_l 0
+BOTH_WALL_RUN_RIGHT      AEV_FOOTSTEP   5 footstep_heavy_r 0
+BOTH_WALL_RUN_RIGHT      AEV_FOOTSTEP  13 footstep_heavy_l 0
+BOTH_WALL_RUN_RIGHT      AEV_FOOTSTEP  21 footstep_heavy_r 0
+BOTH_WALL_RUN_RIGHT_FLIP AEV_FOOTSTEP   1 footstep_heavy_r 0
+BOTH_WALL_RUN_RIGHT_FLIP AEV_SOUNDCHAN  2 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+//Force
+BOTH_FORCE_RAGE AEV_FOOTSTEP 44 footstep_r 0
+BOTH_FORCE_RAGE AEV_FOOTSTEP 45 footstep_l 0
+//Melee
+BOTH_KYLE_GRAB         AEV_FOOTSTEP    1 footstep_r 0
+BOTH_KYLE_MISS         AEV_FOOTSTEP    8 footstep_r 0
+BOTH_KYLE_MISS         AEV_FOOTSTEP   13 footstep_l 0
+BOTH_KYLE_PA_1         AEV_FOOTSTEP    8 footstep_r 0
+BOTH_KYLE_PA_1         AEV_FOOTSTEP  109 footstep_r 0
+BOTH_KYLE_PA_2         AEV_FOOTSTEP   47 footstep_r 0
+BOTH_KYLE_PA_2         AEV_FOOTSTEP  112 footstep_l 0
+BOTH_KYLE_PA_3         AEV_FOOTSTEP   15 footstep_r 0
+BOTH_KYLE_PA_3         AEV_FOOTSTEP   50 footstep_l 0
+BOTH_MELEE_BACKHAND    AEV_FOOTSTEP    1 footstep_l 0
+BOTH_MELEE_BACKHAND    AEV_FOOTSTEP   18 footstep_r 0
+BOTH_MELEE_JUMP_KICK   AEV_SOUNDCHAN   0 CHAN_VOICE *jump1.mp3 0 0 0
+BOTH_MELEE_JUMP_KICK   AEV_SOUNDCHAN   1 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MELEE_LEG_SWEEP   AEV_SOUNDCHAN   4 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MELEE_LEG_SWEEP   AEV_FOOTSTEP   19 footstep_r 0
+BOTH_MELEE_SPIN_KICK_L AEV_FOOTSTEP    3 footstep_r 0
+BOTH_MELEE_SPIN_KICK_L AEV_SOUNDCHAN   5 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MELEE_SPIN_KICK_L AEV_FOOTSTEP   15 footstep_r 0
+BOTH_MELEE_SPIN_KICK_L AEV_FOOTSTEP   17 footstep_l 0
+BOTH_MELEE_SPIN_KICK_R AEV_FOOTSTEP    3 footstep_l 0
+BOTH_MELEE_SPIN_KICK_R AEV_SOUNDCHAN   5 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_MELEE_SPIN_KICK_R AEV_FOOTSTEP   14 footstep_l 0
+BOTH_MELEE_SPIN_KICK_R AEV_FOOTSTEP   20 footstep_r 0
+BOTH_MELEE_UPPERCUT    AEV_FOOTSTEP    2 footstep_r 0
+BOTH_MELEE_UPPERCUT    AEV_FOOTSTEP   19 footstep_r 0
+BOTH_PLAYER_PA_1       AEV_FOOTSTEP   36 footstep_l 0
+BOTH_PLAYER_PA_1       AEV_FOOTSTEP   37 footstep_r 0
+BOTH_PLAYER_PA_2       AEV_SOUNDCHAN  47 CHAN_AUTO sound/player/fallsplat.wav 0 0 0
+BOTH_PLAYER_PA_2       AEV_SOUNDCHAN  66 CHAN_AUTO sound/player/fallsplat.wav 0 0 0
+BOTH_PLAYER_PA_2       AEV_SOUNDCHAN  95 CHAN_AUTO sound/weapons/melee/kick%d.mp3 1 4 0
+BOTH_PLAYER_PA_3       AEV_SOUNDCHAN  97 CHAN_AUTO sound/player/fallsplat.wav 0 0 0
+BOTH_THROW             AEV_FOOTSTEP    8 footstep_heavy_r 0
+BOTH_THROW             AEV_FOOTSTEP   17 footstep_r 0
+BOTH_THROW1            AEV_FOOTSTEP    8 footstep_heavy_r 0
+BOTH_THROW1            AEV_FOOTSTEP   49 footstep_r 0
+BOTH_THROW1            AEV_FOOTSTEP   60 footstep_l 0
+BOTH_THROW2            AEV_FOOTSTEP   35 footstep_r 0
+BOTH_THROWEE           AEV_SOUNDCHAN   2 CHAN_VOICE *choke1.mp3 0 0 0
+BOTH_THROWEE           AEV_SOUNDCHAN   6 CHAN_AUTO sound/weapons/melee/swing%d.mp3 1 4 0
+BOTH_THROWEE           AEV_SOUNDCHAN  15 CHAN_AUTO sound/player/fallsplat.wav 0 0 0
+//Walk
+BOTH_MINIGUN_WALK1     AEV_FOOTSTEP  0 footstep_l 0
+BOTH_MINIGUN_WALK1     AEV_FOOTSTEP  7 footstep_r 0
+BOTH_MINIGUN_WALKBACK1 AEV_FOOTSTEP  0 footstep_r 0
+BOTH_MINIGUN_WALKBACK1 AEV_FOOTSTEP  7 footstep_l 0
+BOTH_WALK1             AEV_FOOTSTEP  6 footstep_r 0
+BOTH_WALK1             AEV_FOOTSTEP 20 footstep_l 0
+BOTH_WALK1TALKCOMM1    AEV_FOOTSTEP  7 footstep_r 0
+BOTH_WALK1TALKCOMM1    AEV_FOOTSTEP 22 footstep_l 0
+BOTH_WALK2             AEV_FOOTSTEP  5 footstep_r 0
+BOTH_WALK2             AEV_FOOTSTEP 18 footstep_l 0
+BOTH_WALK5             AEV_FOOTSTEP  7 footstep_r 0
+BOTH_WALK5             AEV_FOOTSTEP 46 footstep_l 0
+BOTH_WALK6             AEV_FOOTSTEP 10 footstep_r 0
+BOTH_WALK6             AEV_FOOTSTEP 37 footstep_l 0
+BOTH_WALK7             AEV_FOOTSTEP  5 footstep_l 0
+BOTH_WALK7             AEV_FOOTSTEP 15 footstep_r 0
+BOTH_WALKBACK1         AEV_FOOTSTEP  9 footstep_r 0
+BOTH_WALKBACK1         AEV_FOOTSTEP 22 footstep_l 0
+BOTH_WALKBACK2         AEV_FOOTSTEP  9 footstep_r 0
+BOTH_WALKBACK2         AEV_FOOTSTEP 22 footstep_l 0
+BOTH_WALKBACK_DUAL     AEV_FOOTSTEP  7 footstep_r 0
+BOTH_WALKBACK_DUAL     AEV_FOOTSTEP 22 footstep_l 0
+BOTH_WALKBACK_STAFF    AEV_FOOTSTEP  1 footstep_r 0
+BOTH_WALKBACK_STAFF    AEV_FOOTSTEP  7 footstep_l 0
+BOTH_WALK_DUAL         AEV_FOOTSTEP  1 footstep_r 0
+BOTH_WALK_DUAL         AEV_FOOTSTEP  7 footstep_l 0
+BOTH_WALK_STAFF        AEV_FOOTSTEP  1 footstep_r 0
+BOTH_WALK_STAFF        AEV_FOOTSTEP  7 footstep_l 0
+//Walk strafe
+BOTH_MINIGUN_WALK1_STRAFE_L AEV_FOOTSTEP  8 footstep_l 0
+BOTH_MINIGUN_WALK1_STRAFE_L AEV_FOOTSTEP 13 footstep_r 0
+BOTH_MINIGUN_WALK1_STRAFE_R AEV_FOOTSTEP  5 footstep_l 0
+BOTH_MINIGUN_WALK1_STRAFE_R AEV_FOOTSTEP 11 footstep_r 0
+BOTH_WALK1_STRAFE_L         AEV_FOOTSTEP  4 footstep_r 0
+BOTH_WALK1_STRAFE_L         AEV_FOOTSTEP  9 footstep_l 0
+BOTH_WALK1_STRAFE_R         AEV_FOOTSTEP  4 footstep_l 0
+BOTH_WALK1_STRAFE_R         AEV_FOOTSTEP  9 footstep_r 0
+BOTH_WALK_DUAL_STRAFE_L     AEV_FOOTSTEP  7 footstep_r 0
+BOTH_WALK_DUAL_STRAFE_L     AEV_FOOTSTEP 21 footstep_l 0
+BOTH_WALK_DUAL_STRAFE_R     AEV_FOOTSTEP  7 footstep_l 0
+BOTH_WALK_DUAL_STRAFE_R     AEV_FOOTSTEP 21 footstep_r 0
+BOTH_WALK_STAFF_STRAFE_L    AEV_FOOTSTEP  4 footstep_r 0
+BOTH_WALK_STAFF_STRAFE_L    AEV_FOOTSTEP 11 footstep_l 0
+BOTH_WALK_STAFF_STRAFE_R    AEV_FOOTSTEP  4 footstep_l 0
+BOTH_WALK_STAFF_STRAFE_R    AEV_FOOTSTEP 11 footstep_r 0
+//Run
+BOTH_RUN1             AEV_FOOTSTEP  8 footstep_heavy_r 0
+BOTH_RUN1             AEV_FOOTSTEP 20 footstep_heavy_l 0
+BOTH_RUN2             AEV_FOOTSTEP  8 footstep_heavy_r 0
+BOTH_RUN2             AEV_FOOTSTEP 20 footstep_heavy_l 0
+BOTH_RUN4             AEV_FOOTSTEP  1 footstep_heavy_r 0
+BOTH_RUN4             AEV_FOOTSTEP  6 footstep_heavy_l 0
+BOTH_RUNBACK1         AEV_FOOTSTEP  3 footstep_heavy_r 0
+BOTH_RUNBACK1         AEV_FOOTSTEP  8 footstep_heavy_l 0
+BOTH_RUNBACK2         AEV_FOOTSTEP  3 footstep_heavy_r 0
+BOTH_RUNBACK2         AEV_FOOTSTEP  8 footstep_heavy_l 0
+BOTH_RUNBACK4         AEV_FOOTSTEP  1 footstep_heavy_r 0
+BOTH_RUNBACK4         AEV_FOOTSTEP  6 footstep_heavy_l 0
+BOTH_RUNBACK_DUAL     AEV_FOOTSTEP  1 footstep_heavy_l 0
+BOTH_RUNBACK_DUAL     AEV_FOOTSTEP 13 footstep_heavy_r 0
+BOTH_RUNBACK_STAFF    AEV_FOOTSTEP  3 footstep_heavy_l 0
+BOTH_RUNBACK_STAFF    AEV_FOOTSTEP  7 footstep_heavy_r 0
+BOTH_RUN_DUAL         AEV_FOOTSTEP  8 footstep_heavy_r 0
+BOTH_RUN_DUAL         AEV_FOOTSTEP 20 footstep_heavy_l 0
+BOTH_RUN_STAFF        AEV_FOOTSTEP  3 footstep_heavy_r 0
+BOTH_RUN_STAFF        AEV_FOOTSTEP 10 footstep_heavy_l 0
+BOTH_SABERSTAFF_RUN   AEV_FOOTSTEP  3 footstep_heavy_r 0
+BOTH_SABERSTAFF_RUN   AEV_FOOTSTEP 10 footstep_heavy_l 0
+BOTH_WOOKIEE_RAGE_RUN AEV_FOOTSTEP  5 footstep_heavy_r 0
+BOTH_WOOKIEE_RAGE_RUN AEV_FOOTSTEP 17 footstep_heavy_l 0
+//Run strafe
+BOTH_RUN1_STRAFE_L             AEV_FOOTSTEP  0 footstep_heavy_l 0
+BOTH_RUN1_STRAFE_L             AEV_FOOTSTEP  7 footstep_heavy_r 0
+BOTH_RUN1_STRAFE_R             AEV_FOOTSTEP  0 footstep_heavy_r 0
+BOTH_RUN1_STRAFE_R             AEV_FOOTSTEP  7 footstep_heavy_l 0
+BOTH_RUN2_STRAFE_L             AEV_FOOTSTEP  0 footstep_heavy_l 0
+BOTH_RUN2_STRAFE_L             AEV_FOOTSTEP  7 footstep_heavy_r 0
+BOTH_RUN2_STRAFE_R             AEV_FOOTSTEP  0 footstep_heavy_r 0
+BOTH_RUN2_STRAFE_R             AEV_FOOTSTEP  7 footstep_heavy_l 0
+BOTH_RUN_DUAL_STRAFE_L         AEV_FOOTSTEP  0 footstep_heavy_l 0
+BOTH_RUN_DUAL_STRAFE_L         AEV_FOOTSTEP  7 footstep_heavy_r 0
+BOTH_RUN_DUAL_STRAFE_R         AEV_FOOTSTEP  0 footstep_heavy_r 0
+BOTH_RUN_DUAL_STRAFE_R         AEV_FOOTSTEP  7 footstep_heavy_l 0
+BOTH_RUN_STAFF_STRAFE_L        AEV_FOOTSTEP  0 footstep_heavy_l 0
+BOTH_RUN_STAFF_STRAFE_L        AEV_FOOTSTEP  7 footstep_heavy_r 0
+BOTH_RUN_STAFF_STRAFE_R        AEV_FOOTSTEP  0 footstep_heavy_r 0
+BOTH_RUN_STAFF_STRAFE_R        AEV_FOOTSTEP  7 footstep_heavy_l 0
+BOTH_WOOKIEE_RAGE_RUN_STRAFE_L AEV_FOOTSTEP  8 footstep_heavy_r 0
+BOTH_WOOKIEE_RAGE_RUN_STRAFE_L AEV_FOOTSTEP 21 footstep_heavy_l 0
+BOTH_WOOKIEE_RAGE_RUN_STRAFE_R AEV_FOOTSTEP  8 footstep_heavy_l 0
+BOTH_WOOKIEE_RAGE_RUN_STRAFE_R AEV_FOOTSTEP 21 footstep_heavy_r 0
 }


### PR DESCRIPTION
Fills in dead air while also removing clutter or ugly sounds, humanoid has been better organized as well.

Highlights
Removed Dash ending slide sound, added a small dust cloud effect on startup 
Added sound and effect cues for Dark Rage
Added a small heal effect to LEG_STIM
Cleaned up kata sounds to remove overlapping spam, more impactful hit sounds, grabber uses taunt sounds instead of combat Swimming sounds (idle, movement)
Vehicle sounds (mount, dismount, turbo)
Death sounds (body impact)
Tightened up various sound timings
Sounds for new taunts

I am sure I (and you) will have nitpicks immediately upon pushing this but it's a good foundation. Files are under limits and plenty of lines could be sacrificed if we find ourselves over in the future. This should be used as a base for all new animevents; paths can be easily mass replaced if for instance you wanted mechanical swing sounds for droids rather than default. More to follow