### PR TITLE
BP-AP-CS-AS multipliers for Jedi-Sith NPCs

### DIFF
--- a/MBAssets3/ext_data/npcs/jediKOTOR.npc
+++ b/MBAssets3/ext_data/npcs/jediKOTOR.npc
@@ -15,6 +15,9 @@ Revan_Jedi
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier 	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -58,6 +61,9 @@ Bastila
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.1
+	BPmultiplier	1.1
+	CSmultiplier	1.05
 	forceRegenAmount	1.1
 	forcePowerMax	125
 	Pbchance		50
@@ -110,6 +116,10 @@ Jolee
 	MB_ATT_HEALING 1
 	MB_ATT_ANTI_MT 2
 	RESOURCE_FORCE 1
+	BPmultiplier	1.25
+	//APmultiplier  0.96
+	//ASmultiplier	0.96
+	CSmultiplier	0.96
 	saberStyle	5
 	saberStyle	1
 	FP_LEVITATION	1
@@ -165,6 +175,8 @@ Zhar
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 3
 	RESOURCE_FORCE 1
+	//APmultiplier	0.9
+	BPmultiplier	0.8
 	forcePowerMax	140
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -217,6 +229,10 @@ Vandar
 	MB_ATT_HEALING 1
 	MB_ATT_SPEEDLUNGE 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.7
+	//APmultiplier	1.3
+	CSmultiplier	1.12
+	//ASmultiplier	1.12
 	forcePowerMax	150
 	forceRegenAmount	1.45
 	Pbchance 60
@@ -275,6 +291,9 @@ ExileF
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.1
+	BPmultiplier	1.1
+	CSmultiplier	1.05
 	forceRegenAmount	1.1
 	forcePowerMax	125
 	Pbchance		50
@@ -326,6 +345,9 @@ ExileM
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.1
+	BPmultiplier	1.1
+	CSmultiplier	1.05
 	forceRegenAmount	1.1
 	forcePowerMax	125
 	Pbchance		50
@@ -486,6 +508,10 @@ Visas
 	MB_ATT_HEALING 1
 	MB_ATT_ANTI_MT 2
 	RESOURCE_FORCE 1
+	BPmultiplier	1.25
+	//APmultiplier  0.96
+	//ASmultiplier	0.96
+	CSmultiplier	0.96
 	saberStyle	5
 	saberStyle	1
 	FP_LEVITATION	1
@@ -538,6 +564,10 @@ Kreia
 	MB_ATT_HEALING 1
 	MB_ATT_ANTI_MT 2
 	RESOURCE_FORCE 1
+	BPmultiplier	1.25
+	//APmultiplier  0.96
+	//ASmultiplier	0.96
+	CSmultiplier	0.96
 	saberStyle	5
 	saberStyle	1
 	FP_LEVITATION	1

--- a/MBAssets3/ext_data/npcs/jediMOTS.npc
+++ b/MBAssets3/ext_data/npcs/jediMOTS.npc
@@ -79,6 +79,9 @@ Mara_ponytail
 	MB_ATT_TRACKING_BEACON
 	MB_ATT_FLIPKICK 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	//ASmultiplier	1.05
+	CSmultiplier	1.05
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 60
@@ -139,6 +142,9 @@ Mara_dark
 	MB_ATT_TRACKING_BEACON
 	MB_ATT_FLIPKICK 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	//ASmultiplier	1.05
+	CSmultiplier	1.05
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 60

--- a/MBAssets3/ext_data/npcs/jediOT.npc
+++ b/MBAssets3/ext_data/npcs/jediOT.npc
@@ -15,6 +15,9 @@ Luke_Ep4_T
 	MB_ATT_FORCEFOCUS 1
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.1
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.05
 	Pbchance 10
@@ -58,6 +61,9 @@ Luke_Pilot
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.1
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -105,6 +111,9 @@ Luke_Ep5
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.1
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -151,6 +160,9 @@ Luke_Ep5_D
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.1
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -199,6 +211,10 @@ Luke_Ep6
 	MB_ATT_FORCEFOCUS 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.3
+	//APmultiplier  1.2
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.05
 	Pbchance 50
@@ -249,6 +265,10 @@ Luke_Ep6_T
 	MB_ATT_FORCEFOCUS 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.3
+	//APmultiplier  1.2
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.05
 	Pbchance 50
@@ -292,6 +312,10 @@ Luke_GM
 	MB_ATT_GUN_DEFENSE 3
 	MB_ATT_DEFLECT 3
 	RESOURCE_FORCE 1
+	BPmultiplier	1.3
+	//APmultiplier  1.2
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	200
 	forceRegenAmount	2
 	Pbchance 40
@@ -351,6 +375,10 @@ Luke_TM
 	MB_ATT_FORCEFOCUS 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.3
+	//APmultiplier  1.2
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.05
 	Pbchance 50
@@ -400,6 +428,10 @@ Luke_BOBF
 	MB_ATT_FORCEFOCUS 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.3
+	//APmultiplier  1.2
+	CSmultiplier	1.1
+	//ASmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.05
 	Pbchance 50
@@ -449,6 +481,10 @@ Obiwan_OWK
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40
@@ -500,6 +536,10 @@ Obiwan_OWK_G
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40
@@ -550,6 +590,10 @@ Obiwan_OT_R
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40
@@ -598,6 +642,10 @@ Obiwan_OT_H
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40

--- a/MBAssets3/ext_data/npcs/jediPreq.npc
+++ b/MBAssets3/ext_data/npcs/jediPreq.npc
@@ -15,6 +15,9 @@ Aayla
 	MB_ATT_DEXTERITY 3
 	MB_ATT_FLIPKICK 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.90
+	//ASmultiplier	1.15
+	CSmultiplier	1.10
 	forcePowerMax	110
 	forceRegenAmount	1.2
 	Pbchance 40
@@ -64,6 +67,7 @@ Agen
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -115,6 +119,7 @@ Agen_R
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -193,6 +198,10 @@ Anakin_Ep2
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier		1.2
+	BPmultiplier		1.1
+	//ASmultiplier 		1.15
+	CSmultiplier 		1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -242,6 +251,10 @@ Anakin_Ep2_R
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier		1.2
+	BPmultiplier		1.1
+	//ASmultiplier 		1.15
+	CSmultiplier 		1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -290,6 +303,10 @@ Anakin_Ep3
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier		1.2
+	BPmultiplier		1.1
+	//ASmultiplier 		1.15
+	CSmultiplier 		1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 50
@@ -341,6 +358,10 @@ Anakin_Ep3_R
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier		1.2
+	BPmultiplier		1.1
+	//ASmultiplier 		1.15
+	CSmultiplier 		1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 50
@@ -391,6 +412,8 @@ AdiGallia
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 3
 	RESOURCE_FORCE 1
+	//APmultiplier	0.9
+	BPmultiplier	0.8
 	forcePowerMax	140
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -439,6 +462,8 @@ Barriss
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 3
 	RESOURCE_FORCE 1
+	//APmultiplier	0.9
+	BPmultiplier	0.8
 	forcePowerMax	140
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -485,6 +510,10 @@ CinDrallig
 	MB_ATT_FORCEFOCUS 1
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.25
+	BPmultiplier	1.25
+	//ASmultiplier	1.15
+	CSmultiplier	1.15
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -538,6 +567,10 @@ CinDrallig_VG
 	MB_ATT_FORCEFOCUS 1
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.25
+	BPmultiplier	1.25
+	//ASmultiplier	1.15
+	CSmultiplier	1.15
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -590,6 +623,7 @@ Coleman
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -643,6 +677,9 @@ Depa
 	MB_ATT_FORCEFOCUS 1
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.9
+	//APmultiplier	0.75
+	//ASmultiplier 	0.97
 	forcePowerMax	160
 	forceRegenAmount	1.075
 	Pbchance 40
@@ -689,6 +726,7 @@ Eeth
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -744,6 +782,10 @@ JediBrute
 	MB_ATT_WOOKIEE_FURY 1
 	MB_ATT_FP_REPULSE
 	RESOURCE_FORCE 1
+	//APmultiplier	1.5
+	BPmultiplier	1.4
+	//ASmultiplier	.95
+	CSmultiplier	1.05
 	forcePowerMax	150
 	forceRegenAmount	0.9
 	Pbchance 40
@@ -791,6 +833,9 @@ Jocasta
 	MB_ATT_FORCEFOCUS 1
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.9
+	//APmultiplier	0.75
+	//ASmultiplier 	0.97
 	forcePowerMax	160
 	forceRegenAmount	1.075
 	Pbchance 40
@@ -837,6 +882,7 @@ KiAdi
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -889,6 +935,9 @@ KitFisto
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -935,6 +984,9 @@ KitFisto_R
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -980,6 +1032,9 @@ Luminara
 	MB_ATT_FORCEFOCUS 1
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.9
+	//APmultiplier	0.75
+	//ASmultiplier 	0.97
 	forcePowerMax	160
 	forceRegenAmount	1.075
 	Pbchance 40
@@ -1028,6 +1083,10 @@ MaceWindu
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	BPmultiplier	1.2
+	//ASmultiplier 	1.1
+	CSmultiplier    1.15
 	forcePowerMax	110
 	forceRegenAmount	1.25
 	Pbchance 40
@@ -1075,6 +1134,10 @@ MaceWindu_R
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	BPmultiplier	1.2
+	//ASmultiplier 	1.1
+	CSmultiplier    1.15
 	forcePowerMax	110
 	forceRegenAmount	1.25
 	Pbchance 40
@@ -1123,6 +1186,9 @@ Obiwan_Ep1
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.4
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	140
 	forceRegenAmount	1
 	Pbchance 40
@@ -1171,6 +1237,9 @@ Obiwan_Ep1_R
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.4
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	140
 	forceRegenAmount	1
 	Pbchance 40
@@ -1219,6 +1288,9 @@ Obiwan_Ep2
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.4
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	140
 	forceRegenAmount	1
 	Pbchance 40
@@ -1269,6 +1341,9 @@ Obiwan_Ep2_R
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.4
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	140
 	forceRegenAmount	1
 	Pbchance 40
@@ -1318,6 +1393,10 @@ Obiwan_Ep3
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40
@@ -1369,6 +1448,10 @@ Obiwan_Ep3_R
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40
@@ -1420,6 +1503,10 @@ Obiwan_Ep3_H
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40
@@ -1470,6 +1557,7 @@ PloKoon
 	MB_ATT_HEALING 1
 	MB_ATT_DEXTERITY 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.2
 	forcePowerMax	130
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -1523,6 +1611,9 @@ Quigon
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -1569,6 +1660,9 @@ Quigon_R
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -1616,6 +1710,9 @@ Quigon_P
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -1662,6 +1759,9 @@ QuinlanVos
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -1707,6 +1807,7 @@ Saesee
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -1758,6 +1859,7 @@ Saesee_R
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -1814,6 +1916,9 @@ Serra
 	MB_ATT_DEXTERITY 3
 	MB_ATT_FLIPKICK 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.90
+	//ASmultiplier	1.15
+	CSmultiplier	1.10
 	forcePowerMax	110
 	forceRegenAmount	1.2
 	Pbchance 40
@@ -1863,6 +1968,7 @@ ShaakTi
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -1918,6 +2024,10 @@ Yoda
 	MB_ATT_HEALING 1
 	MB_ATT_SPEEDLUNGE 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.7
+	//APmultiplier	1.3
+	CSmultiplier	1.12
+	//ASmultiplier	1.12
 	forcePowerMax	150
 	forceRegenAmount	1.45
 	Pbchance 60
@@ -1979,6 +2089,9 @@ Ahsoka
 	MB_ATT_DEXTERITY 3
 	MB_ATT_FLIPKICK 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.90
+	//ASmultiplier	1.15
+	CSmultiplier	1.10
 	forcePowerMax	110
 	forceRegenAmount	1.2
 	Pbchance 40
@@ -2031,6 +2144,9 @@ Ahsoka_Dual
 	MB_ATT_DEXTERITY 3
 	MB_ATT_FLIPKICK 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.90
+	//ASmultiplier	1.15
+	CSmultiplier	1.10
 	forcePowerMax	110
 	forceRegenAmount	1.2
 	Pbchance 50
@@ -2082,6 +2198,10 @@ Anakin_Ep2_CW
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	BPmultiplier	1.1
+	//ASmultiplier	1.15
+	CSmultiplier	1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 50
@@ -2132,6 +2252,10 @@ Anakin_CW_Yavin4
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	BPmultiplier	1.1
+	//ASmultiplier	1.15
+	CSmultiplier	1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 50
@@ -2183,6 +2307,10 @@ Anakin_CW
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	BPmultiplier	1.1
+	//ASmultiplier	1.15
+	CSmultiplier	1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 50
@@ -2233,6 +2361,10 @@ Anakin_CW_N
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	BPmultiplier	1.1
+	//ASmultiplier	1.15
+	CSmultiplier	1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 50
@@ -2283,6 +2415,10 @@ Anakin_TCW
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	BPmultiplier	1.1
+	//ASmultiplier	1.15
+	CSmultiplier	1.1
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 50
@@ -2334,6 +2470,8 @@ JTGuard
 	MB_ATT_FORCEFOCUS 1
 	MB_ATT_FP_REPULSE
 	RESOURCE_FORCE 1
+	BPmultiplier	1.15
+	//APmultiplier	1.05
 	forcePowerMax	130
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -2386,6 +2524,8 @@ JTGuard_R
 	MB_ATT_SPEEDLUNGE 1
 	MB_ATT_FLOAT_HOP
 	RESOURCE_FORCE 1
+	BPmultiplier	1.15
+	//APmultiplier	1.05
 	forcePowerMax	100
 	forceRegenAmount	1.1
 	Pbchance 50
@@ -2434,6 +2574,9 @@ KitFisto_CW
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -2480,6 +2623,9 @@ KitFisto_TCW
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.3
+	//ASmultiplier	1.05
+	CSmultiplier	1.15
 	forcePowerMax	125
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -2525,6 +2671,10 @@ MaceWindu_CW
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.2
+	BPmultiplier	1.2
+	//ASmultiplier 	1.1
+	CSmultiplier    1.15
 	forcePowerMax	110
 	forceRegenAmount	1.25
 	Pbchance 40
@@ -2574,6 +2724,10 @@ Obiwan_CW
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40
@@ -2624,6 +2778,10 @@ Obiwan_TCW
 	MB_ATT_HEALING 1
 	MB_ATT_BLAST_ARMOUR 1
 	RESOURCE_FORCE 1
+	//APmultiplier	0.8
+	BPmultiplier	1.6
+	CSmultiplier 1.05
+	//ASmultiplier	1.05
 	forcePowerMax	185
 	forceRegenAmount	.85
 	Pbchance 40
@@ -2674,6 +2832,7 @@ PloKoon_TCW
 	MB_ATT_HEALING 1
 	MB_ATT_DEXTERITY 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.2
 	forcePowerMax	130
 	forceRegenAmount	1.1
 	Pbchance 40
@@ -2730,6 +2889,10 @@ Yoda_CW
 	MB_ATT_HEALING 1
 	MB_ATT_SPEEDLUNGE 1
 	RESOURCE_FORCE 1
+	BPmultiplier	0.7
+	//APmultiplier	1.3
+	CSmultiplier	1.12
+	//ASmultiplier	1.12
 	forcePowerMax	200
 	forceRegenAmount	2
 	Pbchance 40

--- a/MBAssets3/ext_data/npcs/jediTFU.npc
+++ b/MBAssets3/ext_data/npcs/jediTFU.npc
@@ -13,6 +13,9 @@ Kota
 	MB_ATT_HEALING 2
 	MB_ATT_FP_REPULSE 1
 	RESOURCE_FORCE 1
+	//APmultiplier		1.15
+	BPmultiplier		1.15
+	//ASmultiplier 		0.95
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -67,6 +70,9 @@ Kota_Drunk
 	MB_ATT_HEALING 2
 	MB_ATT_FP_REPULSE 1
 	RESOURCE_FORCE 1
+	//APmultiplier		1.15
+	BPmultiplier		1.15
+	//ASmultiplier 		0.95
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -125,6 +131,8 @@ Starkiller2_TIE
 	MB_ATT_HEALING 1
 	MB_ATT_FP_REPULSE 1
 	RESOURCE_FORCE 1
+	//ASmultiplier 		1.08
+	CSmultiplier 		1.05
 	forcePowerMax	140
 	forceRegenAmount	1.35
 	Pbchance 60
@@ -182,6 +190,8 @@ Starkiller2_Hero
 	MB_ATT_HEALING 1
 	MB_ATT_FP_REPULSE 1
 	RESOURCE_FORCE 1
+	//ASmultiplier 		1.08
+	CSmultiplier 		1.05
 	forcePowerMax	140
 	forceRegenAmount	1.35
 	Pbchance 60

--- a/MBAssets3/ext_data/npcs/sithKOTOR.npc
+++ b/MBAssets3/ext_data/npcs/sithKOTOR.npc
@@ -12,6 +12,9 @@ Bastila_S
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.1
+	BPmultiplier	1.1
+	CSmultiplier	1.05
 	forceRegenAmount	1.1
 	forcePowerMax	125
 	Pbchance		50
@@ -67,6 +70,10 @@ DarthRevan
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier		1.2
+	BPmultiplier		1.15
+	//ASmultiplier 		1.1
+	CSmultiplier 		1.15
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 60
@@ -118,6 +125,9 @@ DarthMalak
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.05
+	BPmultiplier	1.4
+	CSmultiplier	1.02
 	forcePowerMax	130
 	forceRegenAmount	0.95
 	Pbchance 60
@@ -172,6 +182,10 @@ ExileSith
 	MB_ATT_HEALING 1
 	MB_ATT_WOOKIEE_FURY 1
 	RESOURCE_FORCE 1
+	//APmultiplier		1.2
+	BPmultiplier		1.15
+	//ASmultiplier 		1.1
+	CSmultiplier 		1.15
 	forcePowerMax	120
 	forceRegenAmount	1.1
 	Pbchance 60
@@ -219,6 +233,10 @@ Nihilus
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_ROSHTAUNT
 	RESOURCE_FORCE 1
+	//APmultiplier	0.9
+	BPmultiplier	1.15
+	//ASmultiplier	1.25
+	CSmultiplier	1.2
 	forcePowerMax	150
 	forceRegenAmount	2
 	Pbchance 50
@@ -274,6 +292,10 @@ Sion
 	MB_ATT_WOOKIE_STRENGTH 1
 	MB_ATT_ENV_PROT 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.1
+	//APmultiplier	1.2
+	CSmultiplier 	1.05
+	//ASmultiplier 	1.05
 	forcePowerMax	120
 	Pbchance 50
 	MBchance 4
@@ -328,6 +350,8 @@ Traya
 	MB_ATT_HEALING 3
 	RESOURCE_FORCE 1
 	forceImmunity 2
+	//APmultiplier	0.85
+	BPmultiplier	0.8
 	forcePowerMax	140
 	forceRegenAmount	1
 	Pbchance 50
@@ -388,6 +412,8 @@ Traya_OneHand
 	MB_ATT_HEALING 3
 	RESOURCE_FORCE 1
 	forceImmunity 2
+	//APmultiplier	0.85
+	BPmultiplier	0.8
 	forcePowerMax	140
 	forceRegenAmount	1
 	Pbchance 50

--- a/MBAssets3/ext_data/npcs/sithOT.npc
+++ b/MBAssets3/ext_data/npcs/sithOT.npc
@@ -2,7 +2,7 @@
 DarthVader
 {
 	playerModel	darthvader
-	customSkin	alt_helmet
+	customSkin	L_alt_helmet
 	MBClass		5
 	weapon		WP_SABER
 	saber		Vader_legends3
@@ -21,6 +21,9 @@ DarthVader
 	MB_ATT_BESKAR 2
 	MB_ATT_ENV_PROT 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.35
+	BPmultiplier	1.2
+	//ASMultiplier	1.1
 	forcePowerMax	150
 	forceRegenAmount	0.95
 	Pbchance 40
@@ -65,6 +68,7 @@ DarthVader
 DarthVader_Ep3
 {
 	playerModel	darthvader
+	customSkin	L_default
 	MBClass		5
 	weapon		WP_SABER
 	saber		Vader_legends1
@@ -83,6 +87,9 @@ DarthVader_Ep3
 	MB_ATT_BESKAR 2
 	MB_ATT_ENV_PROT 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.35
+	BPmultiplier	1.2
+	//ASMultiplier	1.1
 	forcePowerMax	150
 	forceRegenAmount	0.95
 	Pbchance 40
@@ -127,7 +134,7 @@ DarthVader_Ep3
 DarthVader_OWK
 {
 	playerModel	darthvader
-	customSkin	tv
+	customSkin	L_tv
 	MBClass		5
 	saber		Vader_legends2
 	weapon		WP_SABER
@@ -146,6 +153,9 @@ DarthVader_OWK
 	MB_ATT_BESKAR 2
 	MB_ATT_ENV_PROT 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.35
+	BPmultiplier	1.2
+	//ASMultiplier	1.1
 	forcePowerMax	150
 	forceRegenAmount	0.95
 	Pbchance 40
@@ -635,6 +645,10 @@ Maul_Rebels
 	MB_ATT_HEALING 1
 	MB_ATT_SABER_COMBO 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.18
+	//APmultiplier	1.18
+	//ASmultiplier	1.10
+	CSmultiplier	1.10
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 50
@@ -684,6 +698,10 @@ Maul_Rebels_NS
 	MB_ATT_HEALING 1
 	MB_ATT_SABER_COMBO 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.18
+	//APmultiplier	1.18
+	//ASmultiplier	1.10
+	CSmultiplier	1.10
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 50
@@ -733,6 +751,10 @@ Maul_Rebels_NSH
 	MB_ATT_HEALING 1
 	MB_ATT_SABER_COMBO 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.18
+	//APmultiplier	1.18
+	//ASmultiplier	1.10
+	CSmultiplier	1.10
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 50

--- a/MBAssets3/ext_data/npcs/sithPreq.npc
+++ b/MBAssets3/ext_data/npcs/sithPreq.npc
@@ -16,6 +16,10 @@ AsajjV
 	MB_ATT_DEXTERITY 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.1
+ 	//APmultiplier	1
+ 	//ASmultiplier	1.10
+ 	CSmultiplier	1.15
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -67,6 +71,10 @@ AsajjV_Staff
 	MB_ATT_DEXTERITY 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.1
+ 	//APmultiplier	1
+ 	//ASmultiplier	1.10
+ 	CSmultiplier	1.15
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -119,6 +127,10 @@ DarthMaul
 	MB_ATT_HEALING 1
 	MB_ATT_SABER_COMBO 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.18
+	//APmultiplier	1.18
+	//ASmultiplier	1.10
+	CSmultiplier	1.10
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -171,6 +183,10 @@ DarthMaul_H
 	MB_ATT_HEALING 1
 	MB_ATT_SABER_COMBO 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.18
+	//APmultiplier	1.18
+	//ASmultiplier	1.10
+	CSmultiplier	1.10
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -221,6 +237,10 @@ DarthMaul_NS
 	MB_ATT_HEALING 1
 	MB_ATT_SABER_COMBO 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.18
+	//APmultiplier	1.18
+	//ASmultiplier	1.10
+	CSmultiplier	1.10
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -270,6 +290,10 @@ Dooku
 	MB_ATT_HEALING 1
 	MB_ATT_DASH 2
 	RESOURCE_FORCE 1
+	//APmultiplier		1.25
+	BPmultiplier		1.25
+	//ASmultiplier 		1.15
+	CSmultiplier 		1.15
 	forcePowerMax	110
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -329,6 +353,10 @@ Grievous
 	MB_ATT_CORTOSIS 1
 	MB_ATT_DEXTERITY 3
 	RESOURCE_FORCE 1
+	//APMultiplier	1.2 
+	BPMultiplier	0.7
+	//ASmultiplier	1.05
+	CSmultiplier	1.4
 	forcePowerMax	120
 	forceRegenAmount	1.15
 	Pbchance 40
@@ -382,6 +410,10 @@ Grievous_NC
 	MB_ATT_CORTOSIS 1
 	MB_ATT_DEXTERITY 3
 	RESOURCE_FORCE 1
+	//APMultiplier	1.2 
+	BPMultiplier	0.7
+	//ASmultiplier	1.05
+	CSmultiplier	1.4
 	forcePowerMax	120
 	forceRegenAmount	1.15
 	Pbchance 40
@@ -428,6 +460,9 @@ Palpatine
 	MB_ATT_FORCEFOCUS 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.35
+	BPmultiplier	0.95
+	//ASmultiplier 1.02
 	forcePowerMax	140
 	forceRegenAmount	1.4
 	Pbchance 40
@@ -480,6 +515,9 @@ Palpatine_BOC
 	MB_ATT_FORCEFOCUS 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.35
+	BPmultiplier	0.95
+	//ASmultiplier 1.02
 	forcePowerMax	140
 	forceRegenAmount	1.4
 	Pbchance 40
@@ -532,6 +570,9 @@ DarthSidious
 	MB_ATT_FORCEFOCUS 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.35
+	BPmultiplier	0.95
+	//ASmultiplier 1.02
 	forcePowerMax	140
 	forceRegenAmount	1.4
 	Pbchance 40
@@ -584,6 +625,9 @@ DarthSidious_Ep3
 	MB_ATT_FORCEFOCUS 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.35
+	BPmultiplier	0.95
+	//ASmultiplier 1.02
 	forcePowerMax	140
 	forceRegenAmount	1.4
 	Pbchance 40
@@ -744,6 +788,10 @@ AsajjV_CW
 	MB_ATT_DEXTERITY 3
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.1
+ 	//APmultiplier	1
+ 	//ASmultiplier	1.10
+ 	CSmultiplier	1.15
 	forcePowerMax	120
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -797,6 +845,10 @@ Dooku_TCW
 	MB_ATT_HEALING 1
 	MB_ATT_DASH 2
 	RESOURCE_FORCE 1
+	//APmultiplier		1.25
+	BPmultiplier		1.25
+	//ASmultiplier 		1.15
+	CSmultiplier 		1.15
 	forcePowerMax	110
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -849,6 +901,10 @@ Dooku_PJ
 	MB_ATT_HEALING 1
 	MB_ATT_DASH 2
 	RESOURCE_FORCE 1
+	//APmultiplier		1.25
+	BPmultiplier		1.25
+	//ASmultiplier 		1.15
+	CSmultiplier 		1.15
 	forcePowerMax	110
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -886,7 +942,7 @@ Dooku_PJ
 }
 
 //Sweggory: Count Dooku, leader of the Separatists ready for a Dark Ritual
-Dooku_PJ
+Dooku_DR
 {
 	playerModel	dooku_dr
 	MBClass		5
@@ -901,6 +957,10 @@ Dooku_PJ
 	MB_ATT_HEALING 1
 	MB_ATT_DASH 2
 	RESOURCE_FORCE 1
+	//APmultiplier		1.25
+	BPmultiplier		1.25
+	//ASmultiplier 		1.15
+	CSmultiplier 		1.15
 	forcePowerMax	110
 	forceRegenAmount	1.04
 	Pbchance 40
@@ -1008,6 +1068,10 @@ SavageO
 	MB_ATT_WOOKIEE_FURY 1
 	MB_ATT_BLAST_ARMOUR
 	RESOURCE_FORCE 1
+	BPmultiplier	1.4
+	//APmultiplier	1.5
+	//ASmultiplier	.95
+	CSmultiplier	1.05
 	forcePowerMax	150
 	forceRegenAmount	0.9
 	Pbchance 40
@@ -1057,6 +1121,10 @@ Maul_TCW_C
 	MB_ATT_HEALING 1
 	MB_ATT_SABER_COMBO 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.18
+	//APmultiplier	1.18
+	//ASmultiplier	1.10
+	CSmultiplier	1.10
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -1106,6 +1174,10 @@ Maul_TCW
 	MB_ATT_HEALING 1
 	MB_ATT_SABER_COMBO 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.18
+	//APmultiplier	1.18
+	//ASmultiplier	1.10
+	CSmultiplier	1.10
 	forcePowerMax	125
 	forceRegenAmount	1.05
 	Pbchance 40
@@ -1159,6 +1231,8 @@ Barriss_Rogue
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 3
 	RESOURCE_FORCE 1
+	//APmultiplier	0.9
+	BPmultiplier	0.8
 	forcePowerMax	140
 	forceRegenAmount	1.1
 	Pbchance 40

--- a/MBAssets3/ext_data/npcs/sithST.npc
+++ b/MBAssets3/ext_data/npcs/sithST.npc
@@ -13,6 +13,8 @@ KyloRen
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.05
+	//APmultiplier	1.15
 	forcePowerMax	110
 	Pbchance 50
 	MBchance 3
@@ -61,6 +63,8 @@ KyloRen_TLJ
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.05
+	//APmultiplier	1.15
 	forcePowerMax	110
 	Pbchance 50
 	MBchance 3
@@ -108,6 +112,8 @@ KyloRen_TROS
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.05
+	//APmultiplier	1.15
 	forcePowerMax	110
 	Pbchance 50
 	MBchance 3
@@ -155,6 +161,8 @@ KyloRen_NM
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.05
+	//APmultiplier	1.15
 	forcePowerMax	110
 	Pbchance 50
 	MBchance 3
@@ -202,6 +210,8 @@ KyloRen_TLJ_NMA
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.05
+	//APmultiplier	1.15
 	forcePowerMax	110
 	Pbchance 50
 	MBchance 3
@@ -249,6 +259,8 @@ KyloRen_TLJ_NMB
 	MB_ATT_FORCEFOCUS 2
 	MB_ATT_HEALING 1
 	RESOURCE_FORCE 1
+	BPmultiplier	1.05
+	//APmultiplier	1.15
 	forcePowerMax	110
 	Pbchance 50
 	MBchance 3

--- a/MBAssets3/ext_data/npcs/sithTFU.npc
+++ b/MBAssets3/ext_data/npcs/sithTFU.npc
@@ -2,7 +2,7 @@
 DarthVader_BD
 {
 	playerModel	darthvader
-	customSkin	damaged
+	customSkin	L_damaged
 	MBClass		5
 	weapon		WP_SABER
 	saber		Vader_legends1
@@ -21,6 +21,9 @@ DarthVader_BD
 	MB_ATT_BESKAR 2
 	MB_ATT_ENV_PROT 1
 	RESOURCE_FORCE 1
+	//APmultiplier	1.35
+	BPmultiplier	1.2
+	//ASMultiplier	1.1
 	forcePowerMax	150
 	forceRegenAmount	0.95
 	Pbchance 40
@@ -80,6 +83,8 @@ Starkiller
 	MB_ATT_HEALING 1
 	MB_ATT_FP_REPULSE 1
 	RESOURCE_FORCE 1
+	//ASmultiplier	1.08
+	CSmultiplier	1.05
 	forcePowerMax	140
 	forceRegenAmount	1.35
 	Pbchance 60
@@ -132,6 +137,8 @@ SithStalker
 	MB_ATT_HEALING 1
 	MB_ATT_FP_REPULSE 1
 	RESOURCE_FORCE 1
+	//ASmultiplier	1.08
+	CSmultiplier	1.05
 	forcePowerMax	140
 	forceRegenAmount	1.35
 	Pbchance 60


### PR DESCRIPTION
AP and AS are commented out since AP causes NPCs to do no BP damage at all and AS breaks NPC's ability to attack at all