### PR TITLE
Sonic Det effects

### DIFF
--- a/MB_Effects/effects/Grenades/EXP_Sonic.efx
+++ b/MB_Effects/effects/Grenades/EXP_Sonic.efx
@@ -8,7 +8,7 @@ Cylinder
 
 	rgb
 	{
-		start			0.5765 0.7882 1 1 1 1
+	start			1 1 1 0.898 0.898 0.898
 	}
 
 	alpha
@@ -65,7 +65,7 @@ Particle
 
 	rgb
 	{
-		start			0.502 0.502 1 0.8 0.8 1
+		start		1 1 1 0.898 0.898 0.898
 	}
 
 	size
@@ -91,7 +91,7 @@ Light
 
 	rgb
 	{
-		start			0.7529 0.9059 0.9961 1 1 1
+		start			1 1 1 0.898 0.898 0.898
 	}
 
 	alpha
@@ -135,7 +135,7 @@ OrientedParticle
 
 	rgb
 	{
-		start			0.5765 0.7882 1
+		start			1 1 1 0.898 0.898 0.898
 	}
 
 	alpha
@@ -185,7 +185,7 @@ OrientedParticle
 
 	rgb
 	{
-		start			0.5765 0.7882 1 1 1 1
+		start			1 1 1 0.898 0.898 0.898
 		flags			linear
 	}
 
@@ -221,7 +221,7 @@ Particle
 
 	rgb
 	{
-		start			0.5765 0.7882 1 1 1 1
+		start			1 1 1 0.898 0.898 0.898
 		flags			linear
 	}
 
@@ -257,8 +257,8 @@ Particle
 
 	rgb
 	{
-		start			0.5765 0.7882 1 1 1 1
-		end				0.5765 0.7882 1 1 1 1
+		start		1 1 1 0.898 0.898 0.898
+		end			1 1 1 0.898 0.898 0.898
 		flags			linear
 	}
 
@@ -296,7 +296,7 @@ OrientedParticle
 
 	rgb
 	{
-		start			0.5765 0.7882 1 1 1 1
+		start			1 1 1 0.898 0.898 0.898
 		flags			linear
 	}
 
@@ -337,7 +337,7 @@ Particle
 
 	rgb
 	{
-		start			0.5765 0.7882 1 1 1 1
+		start			1 1 1 0.898 0.898 0.898
 		flags			linear
 	}
 
@@ -379,7 +379,7 @@ Flash
 
 	rgb
 	{
-		start			1 0.9843 0.9412
+		start		1 1 1 0.898 0.898 0.898
 	}
 
 	alpha
@@ -405,7 +405,7 @@ Particle
 
 	rgb
 	{
-		start			0.5765 0.7882 1 0 1 1
+		start			1 1 1 0.898 0.898 0.898
 		flags			linear
 	}
 

--- a/MB_Effects/effects/Grenades/GlowSonicB.efx
+++ b/MB_Effects/effects/Grenades/GlowSonicB.efx
@@ -6,7 +6,7 @@ Particle
 
 	rgb
 	{
-		start			0.5765 0.7882 1
+	start			1 1 1 0.898 0.898 0.898
 	}
 
 	alpha

--- a/MB_Effects/effects/Grenades/GlowSonicS.efx
+++ b/MB_Effects/effects/Grenades/GlowSonicS.efx
@@ -6,7 +6,7 @@ Particle
 
 	rgb
 	{
-		start			0.5765 0.7882 1
+	start			1 1 1 0.898 0.898 0.898
 	}
 
 	alpha


### PR DESCRIPTION
Instead of being a dupe/near-dupe of Cryo Grenade effects (while always being loaded), Sonic glow and explosion are now a greyer color